### PR TITLE
fix(gate): restore the benchmark gate after the Atlas-Inf migration

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,0 +1,185 @@
+name: Image (gb10)
+
+# Publishes the GB10 runtime image for every commit that lands on main.
+#
+# Until now nothing built `docker/gb10/Dockerfile` outside a human's shell, so
+# the only images that existed were whatever someone last pushed by hand. This
+# gives every main commit an immutable, addressable image and a provenance
+# label pointing back at the source commit.
+#
+# GHCR, not Docker Hub, is canonical. The image then lives under the
+# `atlas-inf` org rather than a personal namespace, and `GITHUB_TOKEN`
+# authenticates to it with no secret to store or rotate. Mirroring to Docker
+# Hub stays a manual pull-and-push, which is why this workflow needs no
+# secrets at all.
+#
+# It does NOT tag `:latest`. `:latest` should mean the newest VERIFIED image,
+# and nothing here runs a kernel — that needs a GB10. Promotion is a separate
+# manual step:
+#
+#     docker buildx imagetools create -t ghcr.io/atlas-inf/atlas-gb10:latest \
+#                                        ghcr.io/atlas-inf/atlas-gb10:sha-<7>
+#
+# which re-points the tag registry-side without rebuilding or re-uploading.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'crates/**'
+      - 'kernels/**'
+      - 'vendor/**'
+      - 'jinja-templates/**'
+      - 'docker/gb10/Dockerfile'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - '.github/workflows/image.yml'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag or SHA to build (default: this workflow's ref)"
+        required: false
+        type: string
+        default: ""
+
+permissions: {}
+
+# NOT cancel-in-progress, unlike the PR workflows. Those produce a verdict on a
+# tip and an older one is worthless; this produces an immutable `:sha-<7>`
+# artifact per commit, and cancelling would leave holes that the promotion
+# command above cannot then point at.
+concurrency:
+  group: image-gb10-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: build and push gb10 image
+    # Native arm64, because the GB10 is arm64 (Grace) — no QEMU emulation,
+    # which would turn a long build into an unusable one. Both base images in
+    # the Dockerfile are digest-pinned, and both digests were checked to be
+    # multi-arch manifest lists carrying linux/arm64, so the pins resolve
+    # natively here.
+    #
+    # Free: this repo is public, and public repos get standard GitHub-hosted
+    # runners at no cost, arm64 included.
+    runs-on: ubuntu-24.04-arm
+    # A full `cargo build --release -p spark-server` with ATLAS_TARGET_MODEL=*
+    # compiles every kernel AND the whole server in release mode. This is by
+    # far the longest job in the repo; the ceiling is set high deliberately so
+    # a slow-but-working build is not reported as a failure. Tighten it once
+    # the first runs have established a real number.
+    timeout-minutes: 240
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE: ghcr.io/atlas-inf/atlas-gb10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Resolve tags
+        id: meta
+        run: |
+          set -euo pipefail
+          # The SHA of what was actually checked out, which for a
+          # workflow_dispatch on some other ref is not github.sha.
+          sha=$(git rev-parse --short=7 HEAD)
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "building $sha"
+
+      - name: Report disk before build
+        run: |
+          set -euo pipefail
+          # A CUDA devel image plus a full release target/ is the one resource
+          # a hosted runner plausibly runs out of. Recorded on both sides so
+          # the first failure is diagnosable rather than mysterious.
+          df -h / | tail -1
+
+      - name: Log in to GHCR
+        env:
+          # GITHUB_TOKEN, not a PAT: `packages: write` above scopes it to this
+          # repository's own packages for the life of the job.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Through the environment rather than `${{ }}` inside the script.
+          # Neither value is attacker-controlled here, but this repo's rule is
+          # that no `github.*` field is ever expanded into a `run:` body (see
+          # cla.yml), and a login line is the wrong place to make an exception.
+          ACTOR: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          docker login "$REGISTRY" -u "$ACTOR" --password-stdin <<<"$GH_TOKEN"
+
+      - name: Build
+        env:
+          SHA: ${{ steps.meta.outputs.sha }}
+        run: |
+          set -euo pipefail
+          # Plain `docker build`, no buildx cache backend and no third-party
+          # build action. Registry-backed layer cache was considered and
+          # deferred: the Dockerfile copies all of crates/ in one layer, so any
+          # source change invalidates the cargo layer and the cache would only
+          # ever save the apt+rustup prologue. Revisit with a number from a
+          # real run rather than on principle.
+          #
+          # ATLAS_GIT_SHA becomes org.opencontainers.image.revision, so
+          #   docker inspect --format \
+          #     '{{ index .Config.Labels "org.opencontainers.image.revision" }}'
+          # answers "what source is this image?" for any tag, including a
+          # :latest that was promoted months later.
+          docker build \
+            -f docker/gb10/Dockerfile \
+            --build-arg "ATLAS_GIT_SHA=$SHA" \
+            -t "$IMAGE:sha-$SHA" \
+            -t "$IMAGE:main" \
+            .
+
+      - name: Report disk after build
+        if: always()
+        run: df -h / | tail -1
+
+      - name: Push
+        env:
+          SHA: ${{ steps.meta.outputs.sha }}
+        run: |
+          set -euo pipefail
+          # `:sha-<7>` is immutable and is what promotion points at.
+          # `:main` is a moving convenience tag for "tip of main, unverified".
+          docker push "$IMAGE:sha-$SHA"
+          docker push "$IMAGE:main"
+
+      - name: Summary
+        if: success()
+        env:
+          SHA: ${{ steps.meta.outputs.sha }}
+        run: |
+          set -euo pipefail
+          {
+            echo "### gb10 image published"
+            echo
+            echo '```'
+            echo "docker pull $IMAGE:sha-$SHA"
+            echo '```'
+            echo
+            echo "Mirror to Docker Hub:"
+            echo
+            echo '```'
+            echo "docker pull $IMAGE:sha-$SHA"
+            echo "docker tag  $IMAGE:sha-$SHA <dockerhub-user>/atlas-gb10:sha-$SHA"
+            echo "docker push <dockerhub-user>/atlas-gb10:sha-$SHA"
+            echo '```'
+            echo
+            echo "Promote to \`:latest\` once verified on real hardware:"
+            echo
+            echo '```'
+            echo "docker buildx imagetools create -t $IMAGE:latest $IMAGE:sha-$SHA"
+            echo '```'
+            echo
+            echo "> First publish creates a **private** package. Make it public once at"
+            echo "> https://github.com/orgs/Atlas-Inf/packages — GHCR does not inherit"
+            echo "> repository visibility."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/kernel-compile.yml
+++ b/.github/workflows/kernel-compile.yml
@@ -90,6 +90,40 @@ jobs:
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
+      # ONE cargo invocation builds what BOTH remaining steps need.
+      #
+      # This was `cargo build -p atlas-kernels`, and the job then paid for the
+      # kernel build twice. Measured on run 33017672173:
+      #
+      #     dev  profile  475/4303 unique nvcc invocations   2m 27s
+      #     test profile  475/4303 unique nvcc invocations   2m 18s   <- identical
+      #     the tests themselves                             ~2s
+      #
+      # Reproduced on a GB10 with ATLAS_SKIP_BUILD=1, which isolates the cargo
+      # graph from nvcc: `cargo build` then `cargo test` leaves TWO build-script
+      # output directories with different metadata hashes
+      # (atlas-kernels-71f8870684ff01d3, atlas-kernels-b03f426489938d35), so
+      # build.rs — and every nvcc call it makes — runs once per directory.
+      #
+      # The cause is in `crates/atlas-kernels/Cargo.toml`: `toml` is declared in
+      # BOTH `[build-dependencies]` and `[dev-dependencies]`. `cargo build`
+      # resolves the graph without dev-dependencies; `cargo test` pulls them in,
+      # which re-fingerprints the build script and forces a second run. Fixing
+      # it in Cargo.toml would mean restructuring a dependency that the tests
+      # legitimately need, so it is fixed here instead: compile through the
+      # TEST graph up front, and the `--ignored` step below reuses it.
+      #
+      # Same graph twice = a cache hit, verified on the GB10: the second
+      # invocation recompiled nothing and returned in 0.05s.
+      #
+      # Deliberately NOT cached with Swatinem/rust-cache. That was the first
+      # plan and the measurement killed it: the whole dependency tree is seven
+      # small crates (winnow, toml_write, toml_datetime, serde_spanned,
+      # toml_edit, toml, atlas-closure) totalling ~3s of compilation. There is
+      # nothing to cache — the job's time is nvcc, which is the point of the
+      # job — and a restored `target/` would additionally make the assertion in
+      # the next step vacuous by leaving a previous run's real `target_ptx.rs`
+      # on disk.
       - name: Compile every gb10 kernel target
         env:
           # ★ NOT set to 1. That is the whole point of this job.
@@ -107,7 +141,9 @@ jobs:
           # promotion ("clippy for kernels"). Reimplementing any of that here
           # would create a second source of truth that drifts silently — and
           # would be a weaker check than the one it imitates.
-          cargo build -p atlas-kernels 2>&1 | tail -40
+          # `--no-run` builds the lib AND the test harnesses without running
+          # them; the run happens in the last step, off these same artifacts.
+          cargo test -p atlas-kernels --no-run 2>&1 | tail -40
 
       - name: Confirm kernels were actually compiled
         run: |
@@ -153,6 +189,9 @@ jobs:
         run: |
           set -euo pipefail
           export PATH="$PATH_CUDA:$PATH"
+          # Recompiles nothing: the step above already built this exact
+          # graph, so this is a cache hit and goes straight to running.
+          #
           # Run every registry test marked "requires nvcc and ATLAS_SKIP_BUILD
           # unset". They assert more than the file count above: every module
           # is non-empty, every module carries a `.version` directive, each

--- a/crates/atlas-plugin/src/gate/amnesty.rs
+++ b/crates/atlas-plugin/src/gate/amnesty.rs
@@ -1,19 +1,39 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-//! Content-pinned amnesty for a boundary-policy bootstrap.
+//! Content-pinned amnesty for the Avarok → Atlas-Inf migration.
 //!
 //! # The grant
 //!
-//! PR #701 changes the benchmark coverage policy so exact Rust modules proven
-//! to be reachable only through `#[cfg(test)]` no longer invalidate GPU
-//! records. The policy, coverage check, and required-set documentation are all
-//! verdict-defining boundary files, so the change invalidates all ten records
-//! before its narrower rule can help later PRs.
+//! Moving the project from `Avarok-Cybersecurity/atlas` to `Atlas-Inf/atlas`
+//! rewrote the org name wherever it appeared — doc comments, plugin metadata
+//! strings, recipe test fixtures, one comment line in a `.cu` — and removed
+//! LatticeDB, a dependency only the host-side governance ledger ever linked.
+//! None of it is executable inference change. `PERF_PATHS` contains the string
+//! `crates`, so all of it invalidated every gate anyway.
 //!
-//! The grant below covers only the final reviewed blobs of those three files.
-//! It is the same mechanism accepted for the 2026-08-16 governance bootstrap:
-//! a table anyone can read, a pin no later edit can inherit, and a test that
-//! demands removal after all ten records have been re-earned.
+//! That alone would cost ten fresh GPU legs. It landed together with a second
+//! problem that makes the bill unpayable: the migration did not carry over the
+//! feature branches the records were measured on, so **every** record's commit
+//! is now absent from the remote and `git diff` cannot even be asked the
+//! question (see `check.rs::invalidating_paths`). The gate reported `NONE` for
+//! all ten benchmarks, which is not dischargeable by re-measuring — a fresh
+//! record would be orphaned by the next branch deletion in exactly the same
+//! way.
+//!
+//! The grant below covers only the final reviewed blobs of the paths that
+//! migration touched. It is the same mechanism PR #701 used and the 2026-08-16
+//! governance bootstrap before it: a table anyone can read, a pin no later
+//! edit can inherit, and a test that demands removal after all ten records
+//! have been re-earned.
+//!
+//! # What is NOT in here
+//!
+//! `crates/atlas-governance` is not amnestied. Its LatticeDB removal is a real
+//! code deletion, not a rename, and pinning it as though it were inert would
+//! be a lie in the table. It is excluded in `coverage.rs` instead, on the
+//! standing `GATE_MACHINERY` rationale — nothing outside `atlas-plugin`'s own
+//! gate bookkeeping and two governance CLI bins links it, and no benchmark
+//! driver or serving path references it at all.
 //!
 //! # Why content-pinned rather than waived
 //!
@@ -38,11 +58,18 @@
 //! own landing would then invalidate everything it exists to protect. It is
 //! covered only by `GATE_MACHINERY`'s cargo-test rationale, like the rest of
 //! the gate bookkeeping. Compensations: the table's exact contents are pinned
-//! by `the_table_is_exactly_the_pr_701_grant` (entry count, paths, OID
+//! by `the_table_is_exactly_the_migration_grant` (entry count, paths, OID
 //! format), every application is logged loudly by `check.rs`, CODEOWNERS
 //! review covers the gate directory, and the gate already executes
 //! PR-checkout code — so this adds no new attack class, only a reviewed
-//! two-file exception to one rule.
+//! exception to one rule.
+//!
+//! This grant is wider than #701's three files, and that is the honest cost of
+//! a repo-wide rename: 38 migration paths, each pinned to one blob, every one
+//! of which a reviewer can diff against `e0a634261b` and see is a string or a
+//! comment — plus this PR's own two boundary-file edits, the same self-pin
+//! #701 needed. The pin is what bounds it: the table cannot cover a single
+//! byte anyone edits after this lands.
 //!
 //! # Removal condition
 //!
@@ -67,25 +94,235 @@ pub struct AmnestyEntry {
     pub grant: &'static str,
 }
 
-/// End of the PR #701 grant day: 2026-08-22T00:00:00Z. A record counts as
+/// End of the migration grant day: 2026-08-26T00:00:00Z. A record counts as
 /// fresh only when it postdates the whole grant day.
-pub const AMNESTY_EPOCH: u64 = 1_787_356_800;
+///
+/// Moved forward from the PR #701 value (2026-08-22T00:00:00Z) because the
+/// records that retired *that* grant are the same ones this grant exists to
+/// rescue: they were measured on branches the migration dropped. Leaving the
+/// epoch behind would let `amnesty_expires_once_every_gate_has_a_fresh_record`
+/// read those pre-migration records as proof this grant is spent.
+pub const AMNESTY_EPOCH: u64 = 1_787_702_400;
 
-/// The PR #701 grant, now EMPTY — it has been fully re-earned and removed.
+/// The Avarok → Atlas-Inf migration grant.
 ///
-/// It covered three boundary files whose landing invalidated all ten GPU
-/// records before the narrower test-only rule could help. Every required gate
-/// has since been re-recorded at 2026-08-22, past `AMNESTY_EPOCH`, so the table
-/// protects nothing; `amnesty_expires_once_every_gate_has_a_fresh_record`
-/// asserts exactly that and demands this removal, which is the designed end of
-/// a one-time grant rather than a change of policy.
+/// Every entry is one path the migration touched inside `PERF_PATHS`, pinned
+/// to the blob this PR lands. Diff any of them against `e0a634261b` — the
+/// newest commit every committed record was measured at — and the change is a
+/// rename in a comment, a URL, a container image name in a test fixture, or
+/// the LatticeDB pruning that removed a host-only governance dependency.
 ///
-/// The mechanism is deliberately kept rather than deleted: the module docs
-/// record why a content-pinned grant was preferred to a path waiver, and
-/// `excused_by` plus its tests stay exercised so the next bootstrap does not
-/// have to re-derive it. An empty table is fail-closed by construction — every
-/// lookup falls through to "not excused".
-pub const ONE_TIME_AMNESTY: [AmnestyEntry; 0] = [];
+/// `crates/atlas-governance` is deliberately absent; see the module docs.
+///
+/// The last two entries are this PR's own `BOUNDARY_FILES` edits. A boundary
+/// file invalidates every gate by construction and no exclusion may exempt one
+/// — that is the lock this list exists to be — so a change to the gate cannot
+/// land without amnestying itself. PR #701 hit the identical wall and pinned
+/// the same two files; see ADR-0015. There is no circularity: the table lives
+/// in `amnesty.rs`, which is not a boundary file, so pinning `check.rs` and
+/// `coverage.rs` does not perturb the blobs being pinned.
+pub const ONE_TIME_AMNESTY: [AmnestyEntry; 40] = [
+    AmnestyEntry {
+        path: "crates/atlas-plugin/src/gate/check.rs",
+        head_blob_oid: "3059ad9a0c64ba585e2b80e7a9bed6c40c782bc0",
+        grant: "this PR's own boundary-file edit: commit_is_present, so a failed diff names the right fault",
+    },
+    AmnestyEntry {
+        path: "crates/atlas-plugin/src/gate/coverage.rs",
+        head_blob_oid: "6c5dc69bac336a7ee75dc0999126e14f1961198d",
+        grant: "this PR's own boundary-file edit: the GOVERNANCE_LEDGER exclusion",
+    },
+    AmnestyEntry {
+        path: "Cargo.lock",
+        head_blob_oid: "b24675fe545e36daf569658fa3c7d73723a08df4",
+        grant: "the LatticeDB removal pruned a host-only governance dependency; no inference crate ever linked it",
+    },
+    AmnestyEntry {
+        path: "Cargo.toml",
+        head_blob_oid: "17171ba4d0b4c9791d4ecffff02eedd1bee80e2e",
+        grant: "the LatticeDB removal pruned a host-only governance dependency; no inference crate ever linked it",
+    },
+    AmnestyEntry {
+        path: "crates/atlas-plugin/src/metadata.rs",
+        head_blob_oid: "6ed89f88b1ac91ba0a22d2024aa80c90bdf11244",
+        grant: "plugin metadata strings - author, URLs, contact - read by no model code",
+    },
+    AmnestyEntry {
+        path: "crates/spark-model/src/layers/dflash_head/from_weights.rs",
+        head_blob_oid: "185ca2b17c7ed538ef3f13668361ae9adac1dfef",
+        grant: "Avarok to Atlas rename in comments and user-facing strings; no executable change",
+    },
+    AmnestyEntry {
+        path: "crates/spark-model/src/layers/moe/mod.rs",
+        head_blob_oid: "ccc89eac025e755262008dc89394ce199fc81702",
+        grant: "Avarok to Atlas rename in comments and user-facing strings; no executable change",
+    },
+    AmnestyEntry {
+        path: "crates/spark-model/src/layers/ops/moe_grouped_a.rs",
+        head_blob_oid: "4f728ee45ac9a5f6284e885d005665d253600404",
+        grant: "Avarok to Atlas rename in comments and user-facing strings; no executable change",
+    },
+    AmnestyEntry {
+        path: "crates/spark-server/src/metrics.rs",
+        head_blob_oid: "a0769ca9ac91cc141ba06086ae9ed2dfb1753095",
+        grant: "Avarok to Atlas rename in comments and user-facing strings; no executable change",
+    },
+    AmnestyEntry {
+        path: "crates/spark-server/src/recipe/fetch.rs",
+        head_blob_oid: "9d103899ad629a4a95ee2387a8346c12b52ce28b",
+        grant: "Avarok to Atlas rename in comments and user-facing strings; no executable change",
+    },
+    AmnestyEntry {
+        path: "crates/spark-server/src/recipe/fetch_tests.rs",
+        head_blob_oid: "0b2d3b00ce0a2f1d5d6a5ece2f842bafb9c9b583",
+        grant: "test-side rebrand string, absent from release builds",
+    },
+    AmnestyEntry {
+        path: "crates/spark-server/src/recipe/mod.rs",
+        head_blob_oid: "bafb0d93669bd106d7068cb56c9dbc3ec749aa00",
+        grant: "Avarok to Atlas rename in comments and user-facing strings; no executable change",
+    },
+    AmnestyEntry {
+        path: "crates/spark-server/src/recipe/yaml_tests.rs",
+        head_blob_oid: "a127c218768b617f4a98b1317f976c807902df01",
+        grant: "test-side rebrand string, absent from release builds",
+    },
+    AmnestyEntry {
+        path: "crates/spark-server/src/tui/data/catalogue_tests.rs",
+        head_blob_oid: "6ad36c98ae1cdc459763a76ea608c2bde2c798c4",
+        grant: "test-side rebrand string, absent from release builds",
+    },
+    AmnestyEntry {
+        path: "crates/spark-server/src/tui/render/render_tests.rs",
+        head_blob_oid: "5a6ff415d00e8aeced1980c112a068dbe081a15f",
+        grant: "test-side rebrand string, absent from release builds",
+    },
+    AmnestyEntry {
+        path: "crates/spark-server/src/tui/report.rs",
+        head_blob_oid: "2862ab0ec4ed82e407f8b05a3800130d855c7f2a",
+        grant: "Avarok to Atlas rename in comments and user-facing strings; no executable change",
+    },
+    AmnestyEntry {
+        path: "crates/spark-server/tests/fixtures/recipes/deepseek-v4/deepseek-v4-flash-nvfp4-ep2.yaml",
+        head_blob_oid: "93da466d0408f0e2e93e7395f25945ea28b51bce",
+        grant: "recipe test fixture: container image name and maintainer strings, never read at serve time",
+    },
+    AmnestyEntry {
+        path: "crates/spark-server/tests/fixtures/recipes/gemma4/gemma-4-26b-a4b-nvfp4.yaml",
+        head_blob_oid: "9d2ed7eaa11e3897332373e1759670684ae2c913",
+        grant: "recipe test fixture: container image name and maintainer strings, never read at serve time",
+    },
+    AmnestyEntry {
+        path: "crates/spark-server/tests/fixtures/recipes/gemma4/gemma-4-31b-nvfp4.yaml",
+        head_blob_oid: "a2dd054079a2fe18ba103dbada653ad885aebbef",
+        grant: "recipe test fixture: container image name and maintainer strings, never read at serve time",
+    },
+    AmnestyEntry {
+        path: "crates/spark-server/tests/fixtures/recipes/minimax-m2.7/minimax-m2.7-nvfp4-ep2.yaml",
+        head_blob_oid: "ec3f47a3fbacf4d8bcd0dd333692a3f57762c28a",
+        grant: "recipe test fixture: container image name and maintainer strings, never read at serve time",
+    },
+    AmnestyEntry {
+        path: "crates/spark-server/tests/fixtures/recipes/mistral-small-4/mistral-small-4-119b-nvfp4.yaml",
+        head_blob_oid: "9d0d779383fd7607e35df9664a9719b915afe014",
+        grant: "recipe test fixture: container image name and maintainer strings, never read at serve time",
+    },
+    AmnestyEntry {
+        path: "crates/spark-server/tests/fixtures/recipes/nemotron-3-nano/nemotron-3-nano-30b-a3b-nvfp4.yaml",
+        head_blob_oid: "236e71e8875397994c00295f358717b9676f7fc4",
+        grant: "recipe test fixture: container image name and maintainer strings, never read at serve time",
+    },
+    AmnestyEntry {
+        path: "crates/spark-server/tests/fixtures/recipes/nemotron-3-super/nemotron-3-super-120b-a12b-nvfp4.yaml",
+        head_blob_oid: "295530239cbd389a6ac100f083dfe403d9fd6398",
+        grant: "recipe test fixture: container image name and maintainer strings, never read at serve time",
+    },
+    AmnestyEntry {
+        path: "crates/spark-server/tests/fixtures/recipes/qwen3-coder-next/qwen3-coder-next-fp8.yaml",
+        head_blob_oid: "a2f72cf6d64f433ef9574e46fc833cfe45c6c962",
+        grant: "recipe test fixture: container image name and maintainer strings, never read at serve time",
+    },
+    AmnestyEntry {
+        path: "crates/spark-server/tests/fixtures/recipes/qwen3-next/qwen3-next-80b-a3b-nvfp4.yaml",
+        head_blob_oid: "cfef5f8fc4fff3e2e1ac54b4e7f684475141cf27",
+        grant: "recipe test fixture: container image name and maintainer strings, never read at serve time",
+    },
+    AmnestyEntry {
+        path: "crates/spark-server/tests/fixtures/recipes/qwen3-vl/qwen3-vl-30b-a3b-nvfp4.yaml",
+        head_blob_oid: "0bfb4feb23d5e7c4ea3754adb713ad9d37d6436b",
+        grant: "recipe test fixture: container image name and maintainer strings, never read at serve time",
+    },
+    AmnestyEntry {
+        path: "crates/spark-server/tests/fixtures/recipes/qwen3.5/qwen3.5-0.8b-bf16-atlas.yaml",
+        head_blob_oid: "9e6ceb5e96b115936b2f16327c7a2f63dd898758",
+        grant: "recipe test fixture: container image name and maintainer strings, never read at serve time",
+    },
+    AmnestyEntry {
+        path: "crates/spark-server/tests/fixtures/recipes/qwen3.5/qwen3.5-122b-a10b-nvfp4-ep2.yaml",
+        head_blob_oid: "78d3f996a10b40baae4671fe05bf6f13f62dd8db",
+        grant: "recipe test fixture: container image name and maintainer strings, never read at serve time",
+    },
+    AmnestyEntry {
+        path: "crates/spark-server/tests/fixtures/recipes/qwen3.5/qwen3.5-122b-a10b-nvfp4-single.yaml",
+        head_blob_oid: "a31ae287c821c5946908720d48b7178931b5fb98",
+        grant: "recipe test fixture: container image name and maintainer strings, never read at serve time",
+    },
+    AmnestyEntry {
+        path: "crates/spark-server/tests/fixtures/recipes/qwen3.5/qwen3.5-27b-dense-nvfp4.yaml",
+        head_blob_oid: "a92c45faf94703280574df79e9dbbc125e6bb963",
+        grant: "recipe test fixture: container image name and maintainer strings, never read at serve time",
+    },
+    AmnestyEntry {
+        path: "crates/spark-server/tests/fixtures/recipes/qwen3.5/qwen3.5-35b-a3b-nvfp4.yaml",
+        head_blob_oid: "315c6f8ece74201d3ac00bd0f3bed55205b82e06",
+        grant: "recipe test fixture: container image name and maintainer strings, never read at serve time",
+    },
+    AmnestyEntry {
+        path: "crates/spark-server/tests/fixtures/recipes/qwen3.6/qwen3.6-27b-fp8-mtp.yaml",
+        head_blob_oid: "97f811ac89dc4a400bfd915f7251c65f76212580",
+        grant: "recipe test fixture: container image name and maintainer strings, never read at serve time",
+    },
+    AmnestyEntry {
+        path: "crates/spark-server/tests/fixtures/recipes/qwen3.6/qwen3.6-27b-fp8.yaml",
+        head_blob_oid: "207dc1be09a73d0c50116c81ed6257da911b3af8",
+        grant: "recipe test fixture: container image name and maintainer strings, never read at serve time",
+    },
+    AmnestyEntry {
+        path: "crates/spark-server/tests/fixtures/recipes/qwen3.6/qwen3.6-27b-nvfp4-prefill-record.yaml",
+        head_blob_oid: "bfd52947f245d971bb22c94be716b31b04b455bd",
+        grant: "recipe test fixture: container image name and maintainer strings, never read at serve time",
+    },
+    AmnestyEntry {
+        path: "crates/spark-server/tests/fixtures/recipes/qwen3.6/qwen3.6-27b-nvfp4.yaml",
+        head_blob_oid: "c842e8d9a26dfe3c45b251480be092079b2bb90b",
+        grant: "recipe test fixture: container image name and maintainer strings, never read at serve time",
+    },
+    AmnestyEntry {
+        path: "crates/spark-server/tests/fixtures/recipes/qwen3.6/qwen3.6-35b-a3b-fp8-bf16head.yaml",
+        head_blob_oid: "4291442fd790729255fcac0bb921f0ba37446c34",
+        grant: "recipe test fixture: container image name and maintainer strings, never read at serve time",
+    },
+    AmnestyEntry {
+        path: "crates/spark-server/tests/fixtures/recipes/qwen3.6/qwen3.6-35b-a3b-fp8-mtp.yaml",
+        head_blob_oid: "55ba5b855579b4f230701ecb67e742ae8d2f9557",
+        grant: "recipe test fixture: container image name and maintainer strings, never read at serve time",
+    },
+    AmnestyEntry {
+        path: "crates/spark-server/tests/fixtures/recipes/qwen3.6/qwen3.6-35b-a3b-fp8-nvfp4head.yaml",
+        head_blob_oid: "9862947f14ca4a7c5ea23dff8862ff47f2e32533",
+        grant: "recipe test fixture: container image name and maintainer strings, never read at serve time",
+    },
+    AmnestyEntry {
+        path: "crates/spark-server/tests/fixtures/recipes/qwen3.6/qwen3.6-35b-a3b-nvfp4.yaml",
+        head_blob_oid: "5b809147c3a6261d74d5b83f97c764a90a268bb1",
+        grant: "recipe test fixture: container image name and maintainer strings, never read at serve time",
+    },
+    AmnestyEntry {
+        path: "kernels/gb10/minimax-m2-229b/nvfp4/moe_w4a16_grouped_gemm.cu",
+        head_blob_oid: "9301c974a8b7ef12b0b1c7a6453b4133a6e1876c",
+        grant: "a comment line in device source; the compiled kernel is byte-identical",
+    },
+];
 
 /// Whether the one-time grant excuses `path` at `head`.
 pub fn excused(root: &Path, head: &str, path: &str) -> bool {

--- a/crates/atlas-plugin/src/gate/amnesty_tests.rs
+++ b/crates/atlas-plugin/src/gate/amnesty_tests.rs
@@ -155,27 +155,28 @@ fn invalidating_paths_drops_exactly_what_the_grant_excuses() {
     );
 }
 
-/// The PR #701 grant is exactly the three boundary files in that change.
-/// Placeholder OIDs keep this test red until the final-content pin commit.
+/// The migration grant covers exactly the paths the migration touched.
+///
+/// The shape assertion is a COUNT and a set of structural rules rather than a
+/// literal path list: at 38 entries a copied list is a second place to update
+/// and a second place to get wrong. What actually bounds the grant is that
+/// every entry is pinned to one blob, so the table cannot cover a byte anyone
+/// edits after it lands — the count keeps it from silently gaining entries.
 #[test]
-fn the_table_is_exactly_the_pr_701_grant() {
-    let paths: Vec<&str> = ONE_TIME_AMNESTY.iter().map(|e| e.path).collect();
-    // The grant has exactly two legal shapes: the three PR #701 boundary files,
-    // or EMPTY once `amnesty_expires_once_every_gate_has_a_fresh_record` has
-    // demanded its removal. Anything else is the grant growing, which is what
-    // this test exists to prevent. Removal is the designed end of a one-time
-    // grant, so it must not read as a violation of it.
-    if !paths.is_empty() {
+fn the_table_is_exactly_the_migration_grant() {
+    // Two legal shapes: the 38 migration paths, or EMPTY once
+    // `amnesty_expires_once_every_gate_has_a_fresh_record` demands removal.
+    // Anything else is the grant growing, which is what this prevents.
+    if !ONE_TIME_AMNESTY.is_empty() {
         assert_eq!(
-            paths,
-            vec![
-                "crates/atlas-plugin/src/gate/check.rs",
-                "crates/atlas-plugin/src/gate/coverage.rs",
-                "crates/atlas-plugin/src/gate/required.rs",
-            ],
-            "the grant must not grow beyond PR #701's boundary files"
+            ONE_TIME_AMNESTY.len(),
+            40,
+            "the grant must not grow beyond the 38 paths the Avarok → Atlas-Inf \
+             migration touched inside PERF_PATHS, plus this PR's own two \
+             BOUNDARY_FILES edits"
         );
     }
+    let mut seen: Vec<&str> = Vec::new();
     for entry in &ONE_TIME_AMNESTY {
         assert_eq!(
             entry.head_blob_oid.len(),
@@ -189,8 +190,25 @@ fn the_table_is_exactly_the_pr_701_grant() {
             entry.path
         );
         assert!(
-            entry.grant.contains("PR #701"),
-            "{} lacks its grant",
+            !entry.grant.is_empty(),
+            "{} lacks its grant rationale",
+            entry.path
+        );
+        // A duplicated path would let a second, unreviewed OID ride along
+        // behind the first: `excused_by` takes the first match and never looks
+        // at the rest, so the shadowed entry would pass review unread.
+        assert!(
+            !seen.contains(&entry.path),
+            "{} appears twice in the grant",
+            entry.path
+        );
+        seen.push(entry.path);
+        // The grant is for content the migration renamed. `atlas-governance`
+        // is a real code deletion and is handled by an exclusion with a
+        // dependency-graph rationale, not by pretending it is inert here.
+        assert!(
+            !entry.path.starts_with("crates/atlas-governance"),
+            "{} belongs in coverage.rs's GOVERNANCE_LEDGER exclusion, not the grant",
             entry.path
         );
     }

--- a/crates/atlas-plugin/src/gate/check.rs
+++ b/crates/atlas-plugin/src/gate/check.rs
@@ -112,6 +112,20 @@ fn record_still_stands(
     }
 }
 
+/// Whether `sha` names a commit object this clone actually holds. Split out so
+/// a failed diff can say WHICH operand is missing: a shallow clone and a
+/// deleted branch both surface as "git diff failed" and have opposite fixes —
+/// deepen the fetch, versus restore a ref.
+pub fn commit_is_present(root: &Path, sha: &str) -> bool {
+    std::process::Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["cat-file", "-e", &format!("{sha}^{{commit}}")])
+        .stdin(std::process::Stdio::null())
+        .output()
+        .is_ok_and(|out| out.status.success())
+}
+
 /// The changed paths that invalidate `gate` between two commits.
 ///
 /// `None` means the question could not be answered — git failed, or one of the
@@ -345,15 +359,27 @@ fn check_one(root: &Path, benchmark_id: &str, sha: &str) -> GateStatus {
                 }
                 let newest = newest_record.git_sha.clone();
                 let Some(why) = invalidating_paths(root, sha, &newest, gate) else {
-                    return GateStatus::Missing(format!(
-                        "latest record is for {newest} ({}) — git cannot diff that commit \
-                         against this one; is it in this clone? (the gate job needs \
-                         `fetch-depth: 0`)",
-                        paths[0]
-                            .file_name()
-                            .map(|n| n.to_string_lossy())
-                            .unwrap_or_default()
-                    ));
+                    let file = paths[0]
+                        .file_name()
+                        .map(|n| n.to_string_lossy())
+                        .unwrap_or_default();
+                    // ★ Name the ACTUAL fault: these two read identically at the
+                    // git level, have opposite remedies, and "needs
+                    // fetch-depth: 0" on a job that already sets it costs the
+                    // reader the investigation.
+                    return GateStatus::Missing(if commit_is_present(root, &newest) {
+                        format!(
+                            "latest record is for {newest} ({file}) — git refused to diff it \
+                             against this commit, though both objects are present"
+                        )
+                    } else {
+                        format!(
+                            "latest record is for {newest} ({file}) — that commit is not in \
+                             this repository, and no fetch depth recovers it: the branch it \
+                             was measured on is gone from the remote. Restore the ref, or \
+                             re-measure on a reachable commit."
+                        )
+                    });
                 };
                 let because = if why.is_empty() {
                     // Reachable only if a record was skipped for a reason other

--- a/crates/atlas-plugin/src/gate/coverage.rs
+++ b/crates/atlas-plugin/src/gate/coverage.rs
@@ -210,6 +210,25 @@ const GATE_MACHINERY: Exclusion = Exclusion {
     rationale: "gate bookkeeping never runs a model; its correctness is covered by cargo test",
 };
 
+/// The governance ledger, on exactly `GATE_MACHINERY`'s rationale.
+///
+/// `atlas-governance` records what PRs were for. Nothing on an inference path
+/// links it: the whole reverse-dependency set is `atlas-plugin`, and inside
+/// that crate the only references are `src/gate/**` — already excluded above —
+/// and the two `ledger_*` CLI bins. No benchmark driver touches it, and
+/// `spark-server`, `spark-model` and `atlas-core` do not name it at all.
+///
+/// ★ Load-bearing precondition, and the reason this is a named constant rather
+/// than an inline entry: the claim is about the DEPENDENCY GRAPH, not about
+/// the files. `governance_exclusion_tests` re-derives it from the manifests
+/// and the sources, so the day someone adds `atlas-governance` to
+/// `spark-server`'s dependencies this exclusion fails a test instead of
+/// silently exempting a crate that now runs in the server.
+const GOVERNANCE_LEDGER: Exclusion = Exclusion {
+    prefix: "crates/atlas-governance",
+    rationale: "the governance ledger never runs a model; no inference crate depends on it",
+};
+
 /// Every other benchmark's driver.
 ///
 /// A change to the BFCL driver can change the BFCL numbers and must invalidate
@@ -229,6 +248,7 @@ const fn other_driver(prefix: &'static str, mine: &'static str) -> Exclusion {
 
 const TTFT_EXCLUDES: &[Exclusion] = &[
     GATE_MACHINERY,
+    GOVERNANCE_LEDGER,
     other_driver(
         "crates/atlas-plugin/src/benchmarks/bfcl",
         "the BFCL driver cannot change what a first-token latency probe measures",
@@ -249,6 +269,7 @@ const TTFT_EXCLUDES: &[Exclusion] = &[
 
 const BFCL_EXCLUDES: &[Exclusion] = &[
     GATE_MACHINERY,
+    GOVERNANCE_LEDGER,
     other_driver(
         "crates/atlas-plugin/src/benchmarks/ttft",
         "the TTFT driver cannot change a tool-calling accuracy score",
@@ -269,6 +290,7 @@ const BFCL_EXCLUDES: &[Exclusion] = &[
 
 const AGENTIC_EXCLUDES: &[Exclusion] = &[
     GATE_MACHINERY,
+    GOVERNANCE_LEDGER,
     other_driver(
         "crates/atlas-plugin/src/benchmarks/ttft",
         "the TTFT driver cannot change whether the agent's webserver task succeeds",
@@ -298,6 +320,7 @@ const AGENTIC_EXCLUDES: &[Exclusion] = &[
 /// replay comes back byte-identical; only the engine can.
 const SSM_POISON_EXCLUDES: &[Exclusion] = &[
     GATE_MACHINERY,
+    GOVERNANCE_LEDGER,
     other_driver(
         "crates/atlas-plugin/src/benchmarks/ttft",
         "the TTFT driver cannot change whether an identical replay returns identical bytes",
@@ -328,6 +351,7 @@ const SSM_POISON_EXCLUDES: &[Exclusion] = &[
 /// measure a single request — they cannot see it.
 const CONCURRENCY_EXCLUDES: &[Exclusion] = &[
     GATE_MACHINERY,
+    GOVERNANCE_LEDGER,
     other_driver(
         "crates/atlas-plugin/src/benchmarks/bfcl",
         "the BFCL driver cannot change the server's latency/throughput curve",
@@ -356,6 +380,7 @@ const CONCURRENCY_EXCLUDES: &[Exclusion] = &[
 /// deliberately NOT here — a change to the pins re-opens the pins.
 const DECODE_FLOOR_EXCLUDES: &[Exclusion] = &[
     GATE_MACHINERY,
+    GOVERNANCE_LEDGER,
     other_driver(
         "crates/atlas-plugin/src/benchmarks/bfcl",
         "the BFCL driver cannot change the server's single-user decode rate",
@@ -384,6 +409,7 @@ const DECODE_FLOOR_EXCLUDES: &[Exclusion] = &[
 /// detector.
 const CONTAMINATION_EXCLUDES: &[Exclusion] = &[
     GATE_MACHINERY,
+    GOVERNANCE_LEDGER,
     other_driver(
         "crates/atlas-plugin/src/benchmarks/ttft",
         "the TTFT driver cannot change whether one request's state leaks into another's output",
@@ -405,6 +431,7 @@ const CONTAMINATION_EXCLUDES: &[Exclusion] = &[
 /// alter vision preprocessing.
 const VISION_EXCLUDES: &[Exclusion] = &[
     GATE_MACHINERY,
+    GOVERNANCE_LEDGER,
     other_driver(
         "crates/atlas-plugin/src/benchmarks/ttft",
         "the TTFT driver cannot change how an image is patched or how many tokens it becomes",

--- a/crates/atlas-plugin/src/gate/governance_exclusion_tests.rs
+++ b/crates/atlas-plugin/src/gate/governance_exclusion_tests.rs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! The load-bearing precondition behind `coverage::GOVERNANCE_LEDGER`.
+//!
+//! Split from `coverage_map_tests.rs` for the 500-LoC cap.
+//!
+//! Excluding `crates/atlas-governance` from every gate is safe for exactly one
+//! reason: nothing that runs a model links it. That is a claim about the
+//! DEPENDENCY GRAPH, not about the files, and it is the kind of claim that
+//! silently stops being true — someone adds a ledger write to the server, and
+//! an exclusion written today starts exempting code that now runs in the
+//! serving path.
+//!
+//! So it is re-derived here from the manifests and the sources on every
+//! `cargo test`, rather than trusted. If it ever fails, the exclusion must go,
+//! not the test.
+
+use super::coverage::REQUIRED;
+
+/// Crates that can execute during a benchmark: the server, the model, the
+/// shared core. If `atlas-governance` becomes reachable from any of them, the
+/// exclusion is a lie.
+const INFERENCE_CRATES: &[&str] = &["spark-server", "spark-model", "atlas-core"];
+
+fn repo_root() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("repo root is two levels above the crate")
+        .to_path_buf()
+}
+
+/// No inference crate may declare `atlas-governance` as a dependency.
+#[test]
+fn governance_is_not_a_dependency_of_any_inference_crate() {
+    let root = repo_root();
+    for krate in INFERENCE_CRATES {
+        let manifest = root.join("crates").join(krate).join("Cargo.toml");
+        let text = std::fs::read_to_string(&manifest)
+            .unwrap_or_else(|e| panic!("{} is unreadable: {e}", manifest.display()));
+        assert!(
+            !text.contains("atlas-governance"),
+            "{krate} now depends on atlas-governance — coverage.rs's GOVERNANCE_LEDGER \
+             exclusion is no longer sound and must be removed"
+        );
+    }
+}
+
+/// Belt and braces: no inference source may name the crate either, which
+/// catches a path dependency added under an alias.
+#[test]
+fn no_inference_source_references_the_governance_crate() {
+    let root = repo_root();
+    for krate in INFERENCE_CRATES {
+        let src = root.join("crates").join(krate).join("src");
+        let mut offenders: Vec<String> = Vec::new();
+        visit(&src, &mut |path, body| {
+            if body.contains("atlas_governance") {
+                offenders.push(path.display().to_string());
+            }
+        });
+        assert!(
+            offenders.is_empty(),
+            "{krate} references atlas_governance in {offenders:?} — GOVERNANCE_LEDGER \
+             must be removed from coverage.rs"
+        );
+    }
+}
+
+/// The exclusion has to actually be installed on every required gate, or the
+/// migration grant's reasoning does not hold for the gates that lack it.
+#[test]
+fn every_required_gate_excludes_the_governance_ledger() {
+    for gate in REQUIRED.iter() {
+        assert!(
+            gate.excludes
+                .iter()
+                .any(|ex| ex.prefix == "crates/atlas-governance"),
+            "{} does not exclude crates/atlas-governance",
+            gate.id
+        );
+    }
+}
+
+/// Walk `dir` recursively, handing every `.rs` file's path and body to `f`.
+fn visit(dir: &std::path::Path, f: &mut impl FnMut(&std::path::Path, &str)) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            visit(&path, f);
+        } else if path.extension().is_some_and(|e| e == "rs")
+            && let Ok(body) = std::fs::read_to_string(&path)
+        {
+            f(&path, &body);
+        }
+    }
+}

--- a/crates/atlas-plugin/src/gate/mod.rs
+++ b/crates/atlas-plugin/src/gate/mod.rs
@@ -225,6 +225,12 @@ mod fixture_baseline;
 #[path = "coverage_map_tests.rs"]
 mod coverage_map_tests;
 
+/// Split from `coverage_map_tests.rs` for the 500-LoC cap: the dependency-graph
+/// precondition behind the `atlas-governance` exclusion.
+#[cfg(test)]
+#[path = "governance_exclusion_tests.rs"]
+mod governance_exclusion_tests;
+
 /// Proofs for the exact, `#[cfg(test)]`-guarded Rust module exemption.
 #[cfg(test)]
 #[path = "test_only_coverage_tests.rs"]

--- a/docs/adr/0017-gate-records-need-their-commit-to-exist.md
+++ b/docs/adr/0017-gate-records-need-their-commit-to-exist.md
@@ -1,0 +1,146 @@
+# ADR-0017: A gate record is only as durable as the commit it names
+
+**Status:** Accepted
+**Date:** 2026-08-25
+**Extends:** ADR-0013 (coverage by content, never by ancestry)
+
+## Context
+
+ADR-0013 removed the ancestry precondition from `record_covers` because Atlas
+squash-merges, and a squash gives the landed commit a new sha with no parent
+link back to the branch the record was measured on. `git diff A B` compares
+trees and needs no history relationship, so the diff alone was kept.
+
+The diff needs one thing the ADR did not state: **both commits must be objects
+this clone actually holds.** Ancestry was dropped; existence was assumed. That
+assumption held for as long as the branches stayed on the remote.
+
+The move from `Avarok-Cybersecurity/atlas` to `Atlas-Inf/atlas` did not carry
+the feature branches over. `Atlas-Inf/atlas` has ten branches: `main`, two port
+branches, six dependabot branches, and one bot branch. Every branch a gate
+record was ever measured on is gone.
+
+The effect on `main` was total and silent:
+
+```
+gate check for 20f1c3a322
+  NONE  agentic-webserver — latest record is for e0a634261b — git cannot diff
+        that commit against this one; is it in this clone? (the gate job needs
+        `fetch-depth: 0`)
+  … the same for all ten required gates
+10 bench(es) still need a passing gate record
+```
+
+Of 502 committed records, **11** name a commit reachable from anything the
+remote still has, and those 11 cover only five of the ten required gates. Five
+gates — `concurrency-sweep`, `decode-floor`, `ssm-state-poisoning-gate`,
+`video-fidelity`, `vision-fidelity` — have zero. No re-run fixes this, and
+`fetch-depth: 0` was already set: the objects are not on the remote to fetch.
+
+Three consequences, in order:
+
+1. `PR benchmark gate` is the only red job on `main` and on every PR.
+2. `dev-release.yml` chains off CI's verdict and skips whenever it is red. It
+   has skipped on all eight runs since the migration.
+3. So the Releases page is empty. All nine release targets — including
+   `linux-x86_64-*` and `windows-x86_64-*` — build green on every run and are
+   discarded when the one-day artifact retention expires.
+
+A GPU perf gate whose records were orphaned by a repo move had, transitively,
+stopped anyone from downloading a binary.
+
+## Decision
+
+**Three changes, each addressing a different one of the three faults.**
+
+### 1. Say which operand is missing
+
+`invalidating_paths` returned `None` for any failed diff, and the caller
+rendered every `None` as "is it in this clone? (the gate job needs
+`fetch-depth: 0`)". A shallow clone and a deleted branch are indistinguishable
+at that level and have opposite remedies. Pointing at a setting that is already
+correct cost the entire investigation.
+
+`check::commit_is_present` now splits the two, and the deleted-branch arm says
+so and says that no fetch depth can recover it.
+
+### 2. Restore the commits the committed records name
+
+The records are evidence, and re-keying them to a commit that happens to exist
+would be falsifying it. The commits are restored instead, under
+`refs/tags/gate-record/<sha>` — a namespace that states why the object is
+retained, is fetched by `actions/checkout` alongside `refs/heads/*`, and cannot
+be confused with a live branch. `e0a634261b` carries 51 commits and 420 objects
+not already in `main`.
+
+**A record's commit must stay reachable for as long as the record is
+committed.** Deleting a branch after merge is fine; deleting it while a record
+names it silently retires that record.
+
+### 3. Amnesty what the migration actually changed
+
+With the commits reachable the gate gives a real verdict, and it is a red one:
+42 `PERF_PATHS` files differ between `e0a634261b` and `main`. Every one is
+inert:
+
+| what changed | files | why it cannot move a number |
+| --- | --- | --- |
+| `Avarok` → `Atlas` in doc comments | 6 | comments; one is a `.cu` comment line |
+| plugin metadata strings | 1 | author, URLs, contact |
+| recipe test fixtures | 27 | container image name, maintainer |
+| `Cargo.toml` / `Cargo.lock` | 2 | LatticeDB pruning |
+| `crates/atlas-governance` | 4 | host-only ledger — see below |
+| **total** | **42** | |
+
+The first four rows go into `ONE_TIME_AMNESTY` — Tom Turney's mechanism from
+PR #701, reused exactly as its docs anticipate. Each of the 38 entries pins the
+blob OID this PR lands, so the grant covers the reviewed bytes and nothing
+else: edit any of those files again and it invalidates at full price.
+
+Two more entries pin this change's own edits to `check.rs` and `coverage.rs`.
+Both are in `BOUNDARY_FILES`, which invalidates every gate by construction and
+which no exclusion may exempt — that is the lock the list exists to be. So a
+change to the gate cannot land without amnestying itself. #701 hit the same
+wall and pinned the same two files. There is no circularity: the table lives in
+`amnesty.rs`, which is not a boundary file, so pinning `check.rs` and
+`coverage.rs` does not perturb the blobs being pinned.
+
+`crates/atlas-governance` is deliberately **not** amnestied. Its change is a
+real code deletion, and pinning it as inert would be a lie in a table whose
+whole value is that a reviewer can trust it. It gets a standing exclusion,
+`GOVERNANCE_LEDGER`, on the same rationale `GATE_MACHINERY` already carries:
+the ledger never runs a model. Its entire reverse-dependency set is
+`atlas-plugin`, and within that crate the only references are `src/gate/**`
+(already excluded) and two `ledger_*` CLI bins. `spark-server`, `spark-model`
+and `atlas-core` do not name it.
+
+That is a dependency-graph claim, so `governance_exclusion_tests` re-derives it
+from the manifests and sources on every `cargo test`. If someone links the
+ledger into the server, the exclusion fails a test rather than quietly
+exempting code that now runs there.
+
+## Consequences
+
+`main` goes green, so `dev-release.yml` publishes `bNNNN` prereleases again and
+the Linux and Windows executables become downloadable for the first time since
+the migration.
+
+The grant is 38 paths where #701's was three. That is the honest price of a
+repo-wide rename, and the pin is what bounds it. `AMNESTY_EPOCH` moves to
+2026-08-26T00:00:00Z: the records that retired the #701 grant are the same ones
+this grant exists to rescue, so leaving the epoch at 2026-08-22 would let
+`amnesty_expires_once_every_gate_has_a_fresh_record` read pre-migration records
+as proof this grant is already spent.
+
+**This does not lower the bar for a real regression.** Every path outside the
+pinned 38 invalidates exactly as before, and the 38 stop being excused the
+moment anyone edits them.
+
+### What this does not fix
+
+A record still dies if its commit becomes unreachable, and the tag namespace is
+a convention that a future migration can forget just as this one did. The
+durable fix is for a record to carry the content it was measured against —
+per-path blob OIDs, or the tree hash — so coverage needs no commit object at
+all. Records already committed have no such field, so it cannot resolve this
+incident; it is the right shape for the next one.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -56,3 +56,4 @@ What's better, what's worse, what new problems did we create?
 - [0014 — PR intent is a descending tree, and it may only ADD benchmarks](0014-pr-intent-taxonomy-and-the-required-union.md)
 - [0015 — The governance harvest, and a one-time content-pinned amnesty](0015-governance-harvest-and-the-one-time-amnesty.md)
 - [0016 — Exempt only proven test-only Rust modules from benchmark invalidation](0016-test-only-rust-module-coverage.md)
+- [0017 — A gate record is only as durable as the commit it names](0017-gate-records-need-their-commit-to-exist.md)


### PR DESCRIPTION
## The bug

`PR benchmark gate` is the **only** red job on `main`, and on every PR. It has been red since the move from `Avarok-Cybersecurity/atlas`:

```
gate check for 20f1c3a322
  NONE  bfcl-subset — latest record is for e0a634261b — git cannot diff that
        commit against this one; is it in this clone? (the gate job needs
        `fetch-depth: 0`)
  … the same for all ten required gates
```

`fetch-depth: 0` was already set. The message named a setting that was already correct.

The real fault: **the migration did not carry the feature branches over.** `Atlas-Inf/atlas` has ten branches — `main`, two port branches, six dependabot, one bot. Every branch a gate record was measured on is gone, so `git diff` cannot be asked the question at all.

| | |
| --- | --- |
| committed records | 502 |
| naming a commit the remote still has | **11** |
| required gates those 11 cover | **5 of 10** |

`concurrency-sweep`, `decode-floor`, `ssm-state-poisoning-gate`, `video-fidelity` and `vision-fidelity` have **zero**. No re-run discharges that — a fresh record would be orphaned by the next branch deletion the same way.

## Why it matters beyond the gate

`dev-release.yml` chains off CI's verdict and skips whenever it is red — **eight runs, eight skips**. So the Releases page is empty, even though all nine release targets build green on every run and are then thrown away by the one-day artifact retention:

| target | artifact | size |
| --- | --- | --- |
| `linux-x86_64-nvidia-cuda` | `spark-linux-x86_64-nvidia-cuda` | 21.3 MB |
| `linux-x86_64-amd-scale` | `spark-linux-x86_64-amd-scale` | 17.4 MB |
| `windows-x86_64-nvidia-cuda` | `spark-windows-x86_64-nvidia-cuda` | 18.2 MB |
| `windows-x86_64-amd-hip` | `spark-windows-x86_64-amd-hip` | 17.9 MB |
| + 5 more | | |

A GPU perf gate whose records were orphaned by a repo move had, transitively, stopped anyone from downloading a binary.

## The fix — three faults, three changes

**1. Say which operand is missing.** `check::commit_is_present` splits a failed diff into its two causes. A shallow clone and a deleted branch are indistinguishable at the git level and have opposite remedies.

**2. Restore the commits the records name.** Pushed as `refs/tags/gate-record/<sha>` — a namespace that states why the object is retained and that `actions/checkout` already fetches alongside `refs/heads/*`. 51 commits, 420 objects. Re-keying the records to a commit that happens to exist would be falsifying evidence.

**3. Amnesty what the migration actually changed.** With the commits reachable the gate gives a real verdict: 42 `PERF_PATHS` files differ between `e0a634261b` and `main`. Every one is inert.

| what changed | files | why it cannot move a number |
| --- | --- | --- |
| `Avarok` → `Atlas` in doc comments | 6 | comments; one is a `.cu` comment line |
| plugin metadata strings | 1 | author, URLs, contact |
| recipe test fixtures | 27 | container image name, maintainer |
| `Cargo.toml` / `Cargo.lock` | 2 | LatticeDB pruning |
| `crates/atlas-governance` | 4 | host-only ledger — excluded, not amnestied |

38 go into `ONE_TIME_AMNESTY` — **Tom Turney's PR #701 mechanism**, reused exactly as its docs anticipate. Each pins the blob OID this PR lands, so the grant covers the reviewed bytes and nothing else.

Two more entries pin this PR's own `check.rs` / `coverage.rs` edits. Both are `BOUNDARY_FILES`, which invalidate every gate by construction and which no exclusion may exempt — so a change to the gate cannot land without amnestying itself. #701 hit the identical wall and pinned the same two files. No circularity: the table lives in `amnesty.rs`, which is not a boundary file.

`crates/atlas-governance` is deliberately **not** amnestied — its change is a real code deletion, and pinning it as inert would be a lie in a table whose whole value is that a reviewer can trust it. It gets a standing exclusion on `GATE_MACHINERY`'s rationale: the ledger never runs a model. Its entire reverse-dependency set is `atlas-plugin`, and inside that crate only `src/gate/**` (already excluded) and two `ledger_*` bins reference it. `governance_exclusion_tests` re-derives that from the manifests and sources on every `cargo test`, so linking the ledger into the server fails a test instead of quietly exempting code that now runs there.

## Verification

Built and run on Linux (strix, x86_64) with the real binary, not a unit test:

```
gate check for b51c923a52
  PASS  agentic-webserver      PASS  ttft-cold-gate
  PASS  vision-fidelity        PASS  bfcl-subset
  PASS  video-fidelity         PASS  bfcl-subset-echolp
  PASS  ttft-warm-gate         PASS  ssm-state-poisoning-gate
  PASS  decode-floor           PASS  concurrency-sweep

all 10 required gates pass          EXIT=0
```

`cargo test -p atlas-plugin --lib` — 820 passed, 0 failed. `cargo fmt --check` and `cargo clippy -p atlas-plugin --tests` clean. `check.rs` is 499 LoC, under the cap.

## This does not lower the bar

Every path outside the pinned 40 invalidates exactly as before, and the 40 stop being excused the moment anyone edits them. `AMNESTY_EPOCH` moves to 2026-08-26 because the records that retired the #701 grant are the same ones this grant exists to rescue — leaving it at 2026-08-22 would let the expiry test read pre-migration records as proof this grant is already spent.

## Known gap

A record still dies if its commit becomes unreachable, and the tag namespace is a convention a future migration can forget just as this one did. The durable fix is for a record to carry the content it was measured against — per-path blob OIDs, or the tree hash — so coverage needs no commit object at all. Records already committed have no such field, so it cannot resolve this incident. Recorded in ADR-0017 as the right shape for the next one.

See ADR-0017.


---

# Also in this PR: the kernel-compile cost, and image publishing

Two additions that are unrelated to the gate, folded in here rather than opened separately.

## 1. `Kernel compile` was building every kernel twice

Run 33017672173, the last green one before this PR:

```
dev  profile   475/4303 unique nvcc invocations   2m 27s
test profile   475/4303 unique nvcc invocations   2m 18s
the tests themselves                              ~2s
```

Identical invocation counts — 138s of a ~390s job was duplicate work, and the tests it exists to run finish in under two seconds.

`toml` is declared in both `[build-dependencies]` and `[dev-dependencies]` of `atlas-kernels`. `cargo build` resolves the graph without dev-dependencies and `cargo test` pulls them in, so the build script was fingerprinted twice and got two output directories (`atlas-kernels-71f8870684ff01d3`, `-b03f426489938d35`), running nvcc once per directory. Fixed by compiling through the **test** graph up front with `cargo test --no-run`, so the `--ignored` step reuses those artifacts instead of resolving its own.

Confirmed in CI on run 33031844239:

```
Compile every gb10 kernel target:            235s
Confirm kernels were actually compiled:        0s
Run the PTX registry tests ...:                2s   <- was 141s
```

Read the within-run numbers, not the total: the compile step alone has drifted 156s → 219s → 235s across runs on identical work, so hosted-runner speed is too noisy for job totals to mean much. The solid result is that one full kernel build per run is gone.

**There is a second, larger cause that is NOT in this PR.** The build script is also *always dirty* — cargo reports `StaleItem(MissingFile { path: ".../kernels/gb10/nllb-200-3.3b/nvfp4" })`, because `build.rs` emits `rerun-if-changed` for (model, quant) directories that don't exist, and cargo treats a missing watched path as permanently stale. That means every incremental `cargo build -p atlas-kernels` on a dev box rebuilds all 4653 nvcc invocations too.

It lives on `fix/kernels-always-dirty-rebuild` and is deliberately held back: it touches `crates/atlas-kernels/build.rs`, which correctly invalidates all ten benchmark gates, so it needs fresh records measured on a GB10. Verified there against real nvcc — cold 46.9s, then two repeat builds at 0.05s each, versus 40.2s then 35.5s before.

**Not** cached with `Swatinem/rust-cache`, which was the original plan. The measurement ruled it out — `atlas-kernels`' entire dependency tree is seven small crates totalling ~3s of compilation. There is nothing to cache; the job's time is nvcc, which is the job's purpose. A restored `target/` would also leave a previous run's real `target_ptx.rs` on disk and make the "kernels were actually compiled" assertion vacuous.

## 2. `image.yml` — publish the gb10 image from main

Nothing built `docker/gb10/Dockerfile` outside a human's shell, so the only images that existed were whatever someone last pushed by hand, and no tag could be traced to a commit. Every commit landing on main now gets an immutable `ghcr.io/atlas-inf/atlas-gb10:sha-<7>`, plus a moving `:main`.

- **GHCR, not Docker Hub.** The image lives under the `atlas-inf` org rather than a personal namespace, and `GITHUB_TOKEN` authenticates to it — **this workflow needs no secrets**. Mirroring to Docker Hub stays a manual pull-and-push; the step summary prints the exact commands.
- **Native arm64** on `ubuntu-24.04-arm`, because the GB10 is arm64 Grace and QEMU would turn a long build into an unusable one. Both base images are digest-pinned, and both digests were checked against the registry — they are multi-arch manifest lists carrying `linux/arm64`, so the pins resolve natively. Public repos get hosted runners at no cost, arm64 included.
- **`--build-arg ATLAS_GIT_SHA`** stamps `org.opencontainers.image.revision`, so the source commit behind any tag is answerable by `docker inspect` alone.
- **Does not tag `:latest`.** `:latest` should mean newest *verified*, and nothing in CI runs a kernel — that needs a GB10. Promotion stays a manual `docker buildx imagetools create`, which re-points the tag registry-side with no rebuild or re-upload.
- **No `cancel-in-progress`,** unlike the PR workflows: those produce a verdict on a tip and a superseded one is worthless, while this produces one immutable artifact per commit, and cancelling would leave holes that promotion cannot point at.

### Two things to know before merging this part

1. **`image.yml` has never run**, and cannot until it is on `main` — `workflow_dispatch` only offers workflows present on the default branch. Its first run is its own first test. The two plausible failure modes are runner disk (a CUDA devel image plus a full release `target/`) and duration; `df` is reported either side of the build so a failure is diagnosable, and the timeout is set deliberately high at 240min so a slow-but-working build is not reported as failure.
2. **GHCR's first publish creates a *private* package** regardless of repository visibility. It has to be made public once, by hand, at https://github.com/orgs/Atlas-Inf/packages.

No layer-cache backend and no third-party build action for now: the Dockerfile copies all of `crates/` in a single layer, so any source change invalidates the cargo layer and a cache would only save the apt+rustup prologue. Worth revisiting with a number from a real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
