### PR TITLE
ci: build what can fail on every PR, defer what can't

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,54 +156,27 @@ jobs:
       # is run locally on GB10 hardware via `-- --ignored`.
       - run: cargo test --workspace --locked
 
-  test-macos-metal:
-    name: cargo test --features metal (macOS aarch64)
-    runs-on: macos-14
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
-      # Apple Silicon path: no CUDA toolchain, no nvcc. The `metal`
-      # feature opts out of cudarc workspace-wide and into the Metal
-      # runtime backend (objc2-metal). xcrun + metallib are part of
-      # macOS's built-in Xcode Command Line Tools and don't need a
-      # separate install on macos-14 runners.
-      # `-p spark-server --features metal` activates the metal
-      # feature on every transitive workspace crate via spark-server's
-      # forwarding feature flags. Single-flag spelling — no long
-      # `atlas-core/metal,spark-runtime/metal,...` comma list needed.
-      - name: cargo check spark-server --features metal
-        run: cargo check -p spark-server --no-default-features --features metal
-      # Also check spark-runtime alone so a regression in the metal
-      # backend tests can be diagnosed independently of higher layers.
-      - name: cargo check spark-runtime --features metal
-        run: cargo check -p spark-runtime --no-default-features --features metal
-      # Build the metal kernel set + run every metal_backend parity
-      # test. The real-model parity tests (`#[ignore]`-gated) require
-      # a local copy of mlx-community/Qwen3.5-4B-MLX-8bit and only
-      # run on a developer machine; default `cargo test` skips them.
-      - name: cargo test -p spark-runtime --features metal
-        env:
-          ATLAS_TARGET_HW: metal
-          ATLAS_TARGET_MODEL: qwen3-5-4b-vlm-mlx-int8
-          ATLAS_TARGET_QUANT: mlx_int8
-        run: |
-          cargo test -p spark-runtime --no-default-features \
-            --features metal --locked metal_backend
-      # Sanity check: the metal-feature spark-server binary must not
-      # link against libcuda. Anything else means a stray
-      # `rustc-link-lib=cuda` directive snuck through a build.rs.
-      - name: assert no libcuda linkage in metal binary
-        run: |
-          cargo build -p spark-server --bin spark --no-default-features --features metal
-          if otool -L target/debug/spark | grep -i cuda; then
-            echo "::error::metal-feature spark binary links libcuda"
-            exit 1
-          fi
-          if otool -L target/debug/spark | grep -i nccl; then
-            echo "::error::metal-feature spark binary links libnccl"
-            exit 1
-          fi
+  # `test-macos-metal` was REMOVED on 2026-08-26.
+  #
+  # It was a ~2.7-minute job, but macOS runners weigh 10x, and at 32 runs a
+  # week it was 867 weighted runner-minutes — the single most expensive thing
+  # in CI once the release matrix went opt-in, and more than every other
+  # non-matrix job in this file combined.
+  #
+  # What it checked, so that restoring it is a copy from git history rather
+  # than a rewrite (`git show <this-commit>^:.github/workflows/ci.yml`):
+  #   - `cargo check -p spark-server --features metal`
+  #   - `cargo check -p spark-runtime --features metal`
+  #   - `cargo test -p spark-runtime --features metal metal_backend`
+  #     (the `metal_backend` parity tests; the real-model ones are
+  #     `#[ignore]`-gated on a local Qwen3.5-4B-MLX-8bit copy and never ran here)
+  #   - `otool -L` on the metal `spark` binary, asserting no libcuda/libnccl
+  #     linkage leaked in through a stray `rustc-link-lib=cuda`
+  #
+  # NOTE: the two `macos-*-metal` entries in `.github/release-matrix.json` are
+  # untouched, so a release still builds and packages macOS binaries. What is
+  # gone is only the per-PR compile-and-test of the metal backend. Nothing
+  # verifies a metal regression on a PR until this comes back.
 
   # cargo-deny runs in security.yml with path filters on Cargo.toml / Cargo.lock /
   # deny.toml plus a weekly cron. Not duplicated here.
@@ -242,7 +215,7 @@ jobs:
       (github.event_name == 'pull_request'
        && contains(github.event.pull_request.labels.*.name, 'build:distros'))
       || (github.event_name == 'workflow_dispatch' && inputs.build_distros)
-    needs: [fmt, clippy, license-headers, typos, kernel-structure, test, test-macos-metal]
+    needs: [fmt, clippy, license-headers, typos, kernel-structure, test]
     uses: ./.github/workflows/release-build.yml
     with:
       version: 0.0.0-pr${{ github.event.number || 'dispatch' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,21 @@ on:
   # can only be started by an event you do not control is a check you cannot
   # get a verdict from when you most need it.
   workflow_dispatch:
+    inputs:
+      build_distros:
+        description: "Also run the 9-platform release build matrix"
+        type: boolean
+        required: false
+        default: false
+  # `labeled` is added to the DEFAULT set (opened/synchronize/reopened) so that
+  # applying `build:distros` to an open PR actually starts a run — without it
+  # the label would only take effect on the next push. Every other label change
+  # also re-runs the cheap gates; that is the price of the opt-in and it is a
+  # few runner-minutes. It cannot recurse through `pr-conflict-label`, which
+  # writes `needs-rebase` with the default GITHUB_TOKEN, and GitHub does not
+  # start workflows from that token's writes.
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
   push:
     branches: [main, master]
   # Merge queue: entries are validated on a temporary `gh-readonly-queue/**`
@@ -17,8 +31,9 @@ on:
   # Every job that is (or becomes) a required check must stay event-agnostic
   # or run here too. Jobs that are event-gated to `pull_request` and NOT
   # required (pr-categorize) are advisory only and need not report on queue
-  # commits. release-matrix and pr-benchmark-gate both run under merge_group
-  # deliberately — see their own comments for why.
+  # commits. pr-benchmark-gate runs under merge_group deliberately — see its
+  # own comment for why. release-matrix no longer does: it is opt-in now, and
+  # nothing in this repo's ruleset makes it required.
   merge_group:
   # Reusable: release.yml gates its (expensive) build matrix on CI passing, so
   # a fmt or clippy failure costs one cheap runner instead of eight toolchain
@@ -193,21 +208,44 @@ jobs:
   # cargo-deny runs in security.yml with path filters on Cargo.toml / Cargo.lock /
   # deny.toml plus a weekly cron. Not duplicated here.
 
-  # The release build matrix runs only after every gate above is green, in
-  # this same CI run — so a PR's checks table shows base CI then the matrix,
-  # and CI is never executed twice for one commit. Guarded to pull_request:
-  # release.yml calls this workflow for its own gate, and must not trigger a
-  # second matrix build there.
+  # OPT-IN. This matrix is nine (OS, arch, GPU) builds — Windows CUDA alone
+  # takes ~34 minutes, and macOS runners bill at 10x — so on 2026-08-26 it was
+  # measured at ~89 of the ~101 runner-minutes a single PR push spent in CI,
+  # roughly 190 BILLABLE minutes once the runner multipliers are applied. It
+  # ran on every push to every PR, which is what made Actions unusable here.
+  #
+  # Distributables are a RELEASE artifact, so they are now built when someone
+  # asks for them, by one of three routes:
+  #
+  #   1. `release.yml` (workflow_dispatch) — the real thing. Takes any `ref`
+  #      and defaults `dry_run: true`, so pointing it at a PR branch builds
+  #      and uploads the full matrix without tagging or publishing anything.
+  #      This is the escape hatch for "does my branch still package?" and it
+  #      needed no new machinery.
+  #   2. `dev-release.yml` — rolling `bNNNN` prereleases off green main.
+  #   3. This job, for when the answer has to appear in the PR's own checks
+  #      table: apply the `build:distros` label, or dispatch CI with
+  #      `build_distros: true`.
+  #
+  # Deliberately NOT gated on merge_group any more. Nothing in this repo's
+  # ruleset (`main-protect`, enforcement `disabled`, rules: deletion +
+  # non_fast_forward) makes this a required check, and there is no merge queue
+  # for it to report into. If a queue is ever turned on and this becomes
+  # required, restore `github.event_name == 'merge_group'` to the condition
+  # below — a required check that never reports hangs every queue entry.
   release-matrix:
     name: release matrix
-    # Runs for pull_request AND merge_group (queue entry validation on the
-    # temporary gh-readonly-queue/** commit). github.event.number is empty
-    # under merge_group, so the version string falls back to "queue".
-    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    # github.event.number is empty on workflow_dispatch, so the version string
+    # falls back to the literal `0.0.0-prdispatch`. It only ever names a
+    # throwaway artifact (retention 1 day) and is never tagged.
+    if: >-
+      (github.event_name == 'pull_request'
+       && contains(github.event.pull_request.labels.*.name, 'build:distros'))
+      || (github.event_name == 'workflow_dispatch' && inputs.build_distros)
     needs: [fmt, clippy, license-headers, typos, kernel-structure, test, test-macos-metal]
     uses: ./.github/workflows/release-build.yml
     with:
-      version: 0.0.0-pr${{ github.event.number || 'queue' }}
+      version: 0.0.0-pr${{ github.event.number || 'dispatch' }}
       pr_mode: true
       retention_days: 1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,10 +241,25 @@ jobs:
   # What it is for right now is evidence. Before any category is allowed to add
   # verification, the log has to show what it would have said, on real pull
   # requests, including the ones where it abstained.
+  # PARKED 2026-08-26, together with governance-harvest.yml, which is the ONLY
+  # consumer of the artifact this job uploads. That workflow has never
+  # succeeded on this repo — it dies at `createPullRequest` because "Allow
+  # GitHub Actions to create and approve pull requests" is off and staying off
+  # — and `governance/` is currently mixing ~95 Avarok-upstream-numbered
+  # ledgers with this repo's own pr-1..pr-13, which has to be untangled before
+  # any of it means anything. With the consumer parked, this job would upload
+  # artifacts nobody reads and spend a model call per push doing it.
+  #
+  # It stays dispatch-reachable so the categoriser can still be exercised
+  # deliberately. Turn it back on in the same commit as governance-harvest.
+  #
+  # Everything below is unchanged and still true when it runs — most
+  # importantly that it is OBSERVE-ONLY and structurally incapable of being
+  # anything else. Re-read the block above the job before re-enabling.
   pr-categorize:
     name: PR categorize (advisory)
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'workflow_dispatch'
     # One live run per PR. The workflow-level group keys on `github.ref`,
     # which serializes compile jobs fine, but a rapid re-push sequence still
     # queued duplicate MODEL CALLS here — and the free tier rate-limits per

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,21 +7,14 @@ on:
   # can only be started by an event you do not control is a check you cannot
   # get a verdict from when you most need it.
   workflow_dispatch:
-    inputs:
-      build_distros:
-        description: "Also run the 9-platform release build matrix"
-        type: boolean
-        required: false
-        default: false
-  # `labeled` is added to the DEFAULT set (opened/synchronize/reopened) so that
-  # applying `build:distros` to an open PR actually starts a run — without it
-  # the label would only take effect on the next push. Every other label change
-  # also re-runs the cheap gates; that is the price of the opt-in and it is a
-  # few runner-minutes. It cannot recurse through `pr-conflict-label`, which
-  # writes `needs-rebase` with the default GITHUB_TOKEN, and GitHub does not
-  # start workflows from that token's writes.
+  # Default types (opened/synchronize/reopened). `labeled` is deliberately NOT
+  # here: this workflow's concurrency group is `cancel-in-progress`, so a run
+  # started by a label would CANCEL the in-flight run for the same ref. Any
+  # label change at all — not just `build:distros` — would kill a CI run that
+  # was most of the way through and restart it from scratch. The opt-in
+  # experimental matrix listens for the label in distros.yml instead, which has
+  # its own concurrency group and cannot disturb this one.
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
   push:
     branches: [main, master]
   # Merge queue: entries are validated on a temporary `gh-readonly-queue/**`
@@ -158,10 +151,28 @@ jobs:
 
   # `test-macos-metal` was REMOVED on 2026-08-26.
   #
-  # It was a ~2.7-minute job, but macOS runners weigh 10x, and at 32 runs a
-  # week it was 867 weighted runner-minutes — the single most expensive thing
-  # in CI once the release matrix went opt-in, and more than every other
-  # non-matrix job in this file combined.
+  # Read the reason carefully, because the obvious one is WRONG. This job was
+  # first cut on a runner-cost argument — ~2.7 minutes at a 10x macOS
+  # multiplier, 32 runs a week. That argument does not hold: this repository is
+  # PUBLIC and every runner in the tree is standard GitHub-hosted, where Actions
+  # minutes are free. The 2x/10x multipliers are private-repo billing.
+  #
+  # What is real is CONCURRENCY. Public repos still sit under a concurrent-job
+  # cap, and the macOS pool is by far the tightest. Before this change each push
+  # asked for THREE macOS jobs at once — this one plus the two `macos-*-metal`
+  # matrix entries — and nine workflows were observed simultaneously queued on
+  # 2026-08-26. Removing this frees the scarcest pool for the two matrix entries
+  # that still want it on a release.
+  #
+  # The second reason is a product call, recorded so it is not mistaken for an
+  # oversight: macOS/Metal is not a priority for this project right now.
+  #
+  # A REJECTED ALTERNATIVE, kept because it is the right fix if metal comes
+  # back: the job ran FOUR compiles of the same code — `cargo check` twice,
+  # then `cargo test`, then `cargo build` — and the two `check`s are subsumed by
+  # the later `build`, buying only a nicer failure message for most of the
+  # job's ~4m41s. Collapsing four compiles into one preserves every assertion
+  # at a fraction of the runtime. Do that rather than restoring it verbatim.
   #
   # What it checked, so that restoring it is a copy from git history rather
   # than a rewrite (`git show <this-commit>^:.github/workflows/ci.yml`):
@@ -181,66 +192,46 @@ jobs:
   # cargo-deny runs in security.yml with path filters on Cargo.toml / Cargo.lock /
   # deny.toml plus a weekly cron. Not duplicated here.
 
-  # OPT-IN. This matrix is nine (OS, arch, GPU) builds — Windows CUDA alone
-  # takes ~34 minutes, and macOS runners bill at 10x — so on 2026-08-26 it was
-  # measured at ~89 of the ~101 runner-minutes a single PR push spent in CI,
-  # roughly 190 BILLABLE minutes once the runner multipliers are applied. It
-  # ran on every push to every PR, which is what made Actions unusable here.
+  # The two builds that can actually fail a PR — and only those two.
   #
-  # Distributables are a RELEASE artifact, so they are now built when someone
-  # asks for them, by one of three routes:
+  # `release-build.yml` sets each build's `continue-on-error` from the entry's
+  # `experimental` flag. Seven of the nine entries in release-matrix.json are
+  # `experimental: true`, which makes them STRUCTURALLY INCAPABLE of turning a
+  # PR red — including `windows-x86_64-nvidia-cuda`, at ~34 minutes the longest
+  # job in this repository. Running them per-push bought latency and queue
+  # pressure in exchange for no verdict at all.
   #
-  #   1. `release.yml` (workflow_dispatch) — the real thing. Takes any `ref`
-  #      and defaults `dry_run: true`, so pointing it at a PR branch builds
-  #      and uploads the full matrix without tagging or publishing anything.
-  #      This is the escape hatch for "does my branch still package?" and it
-  #      needed no new machinery.
-  #   2. `dev-release.yml` — rolling `bNNNN` prereleases off green main.
-  #   3. This job, for when the answer has to appear in the PR's own checks
-  #      table: apply the `build:distros` label, or dispatch CI with
-  #      `build_distros: true`.
+  # The two that DO gate are `linux-x86_64-nvidia-cuda` and
+  # `linux-aarch64-nvidia-cuda`, and they are also the two cheapest: both are
+  # native builds on free hosted runners (`ubuntu-24.04`, `ubuntu-24.04-arm`),
+  # ~8 and ~5 minutes. `linux-aarch64` in particular is the PRIMARY TARGET —
+  # GB10 / DGX Spark is arm64 Grace — so dropping it from PRs would remove
+  # per-PR verification of the one platform this project exists to serve. They
+  # stay, unconditionally, on every PR.
   #
-  # Deliberately NOT gated on merge_group any more. Nothing in this repo's
-  # ruleset (`main-protect`, enforcement `disabled`, rules: deletion +
-  # non_fast_forward) makes this a required check, and there is no merge queue
-  # for it to report into. If a queue is ever turned on and this becomes
-  # required, restore `github.event_name == 'merge_group'` to the condition
-  # below — a required check that never reports hangs every queue entry.
+  # The other seven are opt-in through `distros.yml` (label `build:distros`),
+  # or via `release.yml`'s dispatch with `dry_run: true`, which takes any ref
+  # and needed no new machinery. `dev-release.yml` still cuts rolling `bNNNN`
+  # prereleases off green main.
+  #
+  # Not gated on merge_group: this repo's only ruleset (`main-protect`) is
+  # enforcement `disabled` with just deletion + non_fast_forward, so nothing
+  # here is a required check and there is no queue to report into. If a queue
+  # is ever enabled and this becomes required, restore
+  # `github.event_name == 'merge_group'` below — a required check that never
+  # reports hangs every queue entry.
   release-matrix:
     name: release matrix
-    # github.event.number is empty on workflow_dispatch, so the version string
-    # falls back to the literal `0.0.0-prdispatch`. It only ever names a
-    # throwaway artifact (retention 1 day) and is never tagged.
-    if: >-
-      (github.event_name == 'pull_request'
-       && contains(github.event.pull_request.labels.*.name, 'build:distros'))
-      || (github.event_name == 'workflow_dispatch' && inputs.build_distros)
+    if: github.event_name == 'pull_request'
     needs: [fmt, clippy, license-headers, typos, kernel-structure, test]
     uses: ./.github/workflows/release-build.yml
     with:
-      version: 0.0.0-pr${{ github.event.number || 'dispatch' }}
+      version: 0.0.0-pr${{ github.event.number }}
       pr_mode: true
+      # The whole point: gating entries only.
+      include_experimental: false
       retention_days: 1
 
-  # OBSERVE-ONLY, and structurally incapable of being anything else.
-  #
-  # This job asks a language model what the pull request is *for*, and records
-  # the answer. It does not gate. `pr-benchmark-gate` below neither `needs:`
-  # this job nor reads its outputs — the `--pr` flag that job now passes keys
-  # a lookup of the COMMITTED governance ledger in the checked-out tree, which
-  # only a default-branch harvester can write, so nothing this job emits can
-  # reach that gate inside the same run. There is no path — not a slow one,
-  # not a subtle one — by which this reaches a verdict. That separation is the
-  # design, not a rollout stage: the inputs are attacker-controlled (a PR's
-  # title and body are written by whoever opened it), and arranging for that
-  # text to be UNABLE to affect verification is stronger than hoping a model
-  # resists it. The one input that is NOT attacker-controlled on a fork —
-  # labels, which need triage permission — is exactly the one allowed to
-  # short-circuit the model. See the override step.
-  #
-  # What it is for right now is evidence. Before any category is allowed to add
-  # verification, the log has to show what it would have said, on real pull
-  # requests, including the ones where it abstained.
   # PARKED 2026-08-26, together with governance-harvest.yml, which is the ONLY
   # consumer of the artifact this job uploads. That workflow has never
   # succeeded on this repo — it dies at `createPullRequest` because "Allow

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,9 +8,11 @@ name: Coverage
 #
 # Cost note: this is a second full instrumented compile of the workspace, on
 # top of ci.yml's `test` job (they cannot share artifacts — `-C
-# instrument-coverage` is a different profile). Runner capacity DID become the
-# constraint; the `pull_request` trigger is gone as of 2026-08-26 and the job
-# now runs on main and weekly. See the trigger block below.
+# instrument-coverage` is a different profile). Capacity did become the
+# constraint, and this note's own advice was taken: as of 2026-08-26 the
+# `pull_request` trigger sits behind a path filter on `crates/**` rather than
+# being deleted, and main + a weekly cron carry the trend. See the trigger
+# block below.
 
 on:
   # Manually runnable. During the 2026-08-06 Actions incident, webhook triggers
@@ -19,24 +21,30 @@ on:
   # can only be started by an event you do not control is a check you cannot
   # get a verdict from when you most need it.
   workflow_dispatch:
-  # NO `pull_request` trigger as of 2026-08-26.
+  # PATH-FILTERED on PRs, as this file's own cost note asked for.
   #
-  # This job is a SECOND full instrumented compile of the workspace, on top of
-  # ci.yml's `test` job — they cannot share artifacts, because
-  # `-C instrument-coverage` is a different profile. It was 108 runner-minutes
-  # a week, all of it duplicating a compile that had already happened in the
-  # same PR.
+  # This is a second full instrumented compile of the workspace on top of
+  # ci.yml's `test` job — they cannot share artifacts, `-C instrument-coverage`
+  # is a different profile. An earlier revision of this branch deleted the
+  # `pull_request` trigger outright. That was the wrong lever: the argument for
+  # it was runner cost, and this repository is PUBLIC on standard hosted
+  # runners, where Actions minutes are free. The 2x/10x multipliers are
+  # private-repo billing and do not apply. The real constraint is concurrent-job
+  # capacity, and this is one ubuntu job — it does not compete for the scarce
+  # macOS pool.
   #
-  # Neither Codecov status is a required check (this repo's only ruleset,
-  # `main-protect`, is enforcement `disabled` and carries just deletion +
-  # non_fast_forward), so nothing was ever gated on the per-PR number — it was
-  # a graph nobody was blocked by. The trend is what the graph is for, and a
-  # trend does not need a point per push: main after every merge, plus a
-  # weekly floor so a quiet week still plots.
-  #
-  # The cost of this: a coverage regression is now visible after merge rather
-  # than during review. If you want the number on a specific PR, dispatch this
-  # workflow against its branch.
+  # So the filter, not the axe. Honest about what it buys: `crates/**` is where
+  # essentially all the code lives, so 11 of the last 14 PRs still match it.
+  # It skips docs-only, CI-only and workflow-only PRs — worth having, not a
+  # large cut. Keep `cargo llvm-cov --workspace` and this filter in sync; a
+  # workspace-wide command behind a narrower filter reports stale coverage.
+  pull_request:
+    paths:
+      - 'crates/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/coverage.yml'
+      - 'codecov.yml'
   push:
     branches: [main, master]
   schedule:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,11 +6,11 @@ name: Coverage
 # without wedging the merge button. This comment said `informational: true` for
 # as long as they were, and it outlived them by one commit.
 #
-# Cost note: this is a second full instrumented compile of the workspace on
-# every PR, on top of ci.yml's `test` job (they cannot share artifacts —
-# `-C instrument-coverage` is a different profile). If runner capacity ever
-# becomes the constraint, move the `pull_request` trigger behind a path filter
-# on `crates/**` rather than deleting the job.
+# Cost note: this is a second full instrumented compile of the workspace, on
+# top of ci.yml's `test` job (they cannot share artifacts — `-C
+# instrument-coverage` is a different profile). Runner capacity DID become the
+# constraint; the `pull_request` trigger is gone as of 2026-08-26 and the job
+# now runs on main and weekly. See the trigger block below.
 
 on:
   # Manually runnable. During the 2026-08-06 Actions incident, webhook triggers
@@ -19,16 +19,32 @@ on:
   # can only be started by an event you do not control is a check you cannot
   # get a verdict from when you most need it.
   workflow_dispatch:
-  pull_request:
+  # NO `pull_request` trigger as of 2026-08-26.
+  #
+  # This job is a SECOND full instrumented compile of the workspace, on top of
+  # ci.yml's `test` job — they cannot share artifacts, because
+  # `-C instrument-coverage` is a different profile. It was 108 runner-minutes
+  # a week, all of it duplicating a compile that had already happened in the
+  # same PR.
+  #
+  # Neither Codecov status is a required check (this repo's only ruleset,
+  # `main-protect`, is enforcement `disabled` and carries just deletion +
+  # non_fast_forward), so nothing was ever gated on the per-PR number — it was
+  # a graph nobody was blocked by. The trend is what the graph is for, and a
+  # trend does not need a point per push: main after every merge, plus a
+  # weekly floor so a quiet week still plots.
+  #
+  # The cost of this: a coverage regression is now visible after merge rather
+  # than during review. If you want the number on a specific PR, dispatch this
+  # workflow against its branch.
   push:
     branches: [main, master]
-  # Merge queue: entries are validated on a temporary gh-readonly-queue/**
-  # merge-commit that fires none of the events above, and this job is in the
-  # required set the queue waits on — without this trigger it is never
-  # reported and every entry times out. The Codecov upload stays advisory
-  # here exactly as on PRs (continue-on-error + a loud warning): a queue
-  # entry must never hang on Codecov availability.
-  merge_group:
+  schedule:
+    # Sunday 06:23 UTC. Offset off the hour for the usual reason — cron at
+    # :00 contends with everyone else's cron on shared runners.
+    - cron: '23 6 * * 0'
+  # No `merge_group` either: it was here only because this was believed to be
+  # in the required set the queue waits on. It is not, and there is no queue.
 
 # Least privilege, same as ci.yml: this workflow only reads the repo. The
 # Codecov upload authenticates with a repository upload token (see the upload

--- a/.github/workflows/distros.yml
+++ b/.github/workflows/distros.yml
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# The full 9-platform distributable matrix, on request.
+#
+# WHY THIS IS A SEPARATE FILE, and not a label-gated job inside ci.yml.
+#
+# ci.yml's concurrency group is `${{ github.workflow }}-${{ github.ref }}` with
+# `cancel-in-progress: true`. If ci.yml subscribed to `pull_request: [labeled]`
+# so that a label could start the matrix, then EVERY label change on a PR —
+# `bug`, `area:kernels`, anything — would land in that group and cancel the
+# in-flight CI run for the same ref, restarting fmt/clippy/tests from scratch.
+# The trigger cannot be narrowed to one label name; `types:` filters on the
+# event, not on which label was applied.
+#
+# So the opt-in lives here, under its own concurrency group, where starting it
+# cannot disturb a running CI. The label check happens at the job level, where
+# `github.event.label.name` IS available.
+#
+# What ci.yml still runs on every PR is the two entries that can actually fail
+# a run (`experimental: false`): linux-x86_64-nvidia-cuda and
+# linux-aarch64-nvidia-cuda. This workflow adds the seven that cannot — they
+# carry `continue-on-error`, so they report but never gate.
+name: Distros (opt-in)
+
+on:
+  # Applying the label starts a run immediately. Removing it does nothing:
+  # `labeled` fires only on add, and a build already in flight is not something
+  # un-labelling should kill.
+  pull_request:
+    types: [labeled]
+  # Any branch, no label needed. Use this when you want the packages without
+  # opening or touching a PR.
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag or SHA to build (default: this workflow's ref)"
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  # Deliberately NOT the same group as ci.yml — see the header. Superseding an
+  # earlier request for the same ref is still right: only the newest tree is
+  # worth packaging, and these are the longest jobs in the repo.
+  group: distros-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  matrix:
+    name: distros
+    # On `labeled`, build only when it is OUR label. Every other label change
+    # starts a run that resolves to this `if` and stops, costing nothing.
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || github.event.label.name == 'build:distros'
+    uses: ./.github/workflows/release-build.yml
+    with:
+      version: 0.0.0-pr${{ github.event.pull_request.number || 'dispatch' }}
+      ref: ${{ inputs.ref || '' }}
+      pr_mode: true
+      # The reason this workflow exists: everything, experimental included.
+      include_experimental: true
+      # Same as ci.yml's. These are throwaway artifacts for eyeballing a
+      # package; a real release publishes through release.yml.
+      retention_days: 1

--- a/.github/workflows/governance-harvest.yml
+++ b/.github/workflows/governance-harvest.yml
@@ -16,20 +16,54 @@ name: Governance harvest
 # (head_sha → commits/{sha}/pulls), never from anything the artifact claims,
 # and the binary rejects any event line disagreeing with it.
 
+# ---------------------------------------------------------------------------
+# PARKED 2026-08-26 — dispatch-only. Not deleted, not needed right now.
+#
+# Two reasons, one practical and one about scope.
+#
+# 1. IT HAS NEVER SUCCEEDED ON THIS REPO. Eleven of the last fifteen runs
+#    failed, all at the same line, after doing the entire job:
+#
+#      pull request create failed: GraphQL: GitHub Actions is not permitted
+#      to create or approve pull requests (createPullRequest)
+#
+#    That is the org/repo setting Settings -> Actions -> General -> "Allow
+#    GitHub Actions to create and approve pull requests", which is off and is
+#    staying off. So every run harvested the ledgers, force-pushed
+#    `bot/governance-harvest`, and then died — a third of this repo's red
+#    checks were this one toggle, and none of them meant anything was wrong
+#    with the tree.
+#
+# 2. THE LEDGER NAMESPACE IS COLLIDING. `governance/` holds ~95 files named
+#    pr-502.jsonl .. pr-537.jsonl, which are AVAROK UPSTREAM pr numbers
+#    inherited through the Atlas-Inf migration. The harvester is now writing
+#    pr-1.jsonl .. pr-13.jsonl for THIS repo into the same directory, so two
+#    unrelated numbering schemes are accumulating in one namespace with
+#    nothing distinguishing them. That has to be resolved before the ledger
+#    means anything, and it is not a CI change.
+#
+# `pr-categorize` in ci.yml — the job that PRODUCES the artifact this
+# workflow consumes — is parked in the same commit and for the same reason.
+# Turn them back on together, or the artifacts pile up unread.
+#
+# To resume: restore the `workflow_run` and `schedule` triggers below, flip
+# the repo setting, and decide what happens to the upstream-numbered ledgers.
+# ---------------------------------------------------------------------------
 on:
-  # The moment a CI run finishes, its ledger artifact is ready. This fires for
-  # every CI completion (push, merge_group, dispatch too); the job-level `if`
-  # keeps only pull_request runs, which are the only ones that produce a
-  # governance artifact.
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
-  schedule:
-    # Daily backstop: sweeps the last 3 days of completed pull_request CI runs,
-    # so a harvest that raced, failed, or was skipped is retried while the
-    # artifact (30-day retention) is still alive. Dedup by Event::identity
-    # makes the re-harvest converge instead of accumulating.
-    - cron: "43 5 * * *"
+  # PARKED: fired on every CI completion; the job-level `if` kept only
+  # pull_request runs, which are the only ones producing a governance artifact.
+  #
+  # workflow_run:
+  #   workflows: ["CI"]
+  #   types: [completed]
+  #
+  # PARKED: daily backstop sweeping the last 3 days of completed pull_request
+  # CI runs, so a harvest that raced, failed or was skipped got retried while
+  # the artifact (30-day retention) was still alive. Dedup by Event::identity
+  # made the re-harvest converge instead of accumulating.
+  #
+  # schedule:
+  #   - cron: "43 5 * * *"
   workflow_dispatch:
     inputs:
       run_id:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -29,6 +29,15 @@ on:
         required: false
         type: boolean
         default: false
+      include_experimental:
+        description: >-
+          PR mode only. false selects ONLY the entries that can fail the run
+          (experimental=false); true selects every pr_validate entry, as a
+          release does. Ignored when pr_mode is false — a release always
+          builds everything.
+        required: false
+        type: boolean
+        default: true
       retention_days:
         description: "Artifact retention"
         required: false
@@ -114,14 +123,37 @@ jobs:
           # Entries with pr_validate=false are physically impossible here (the
           # SCALE toolchain is not redistributable) — they are reported as NOT
           # VALIDATED rather than passed vacuously.
+          #
+          # `include_experimental` splits the PR set further, and the split is
+          # about SIGNAL, not cost. The `build` job below sets its
+          # `continue-on-error` from the entry's `experimental` flag, so the seven
+          # experimental entries are STRUCTURALLY INCAPABLE of failing a run —
+          # including the 34-minute Windows CUDA build, the longest job in CI.
+          # On a PR they are latency with no verdict attached. The two entries
+          # that can actually turn a PR red are exactly the two native Linux
+          # builds, and one of them (linux-aarch64) is the primary target: GB10
+          # / DGX Spark is arm64 Grace. Those two run on every PR. The other
+          # seven are opt-in via distros.yml.
           if [ "${{ inputs.pr_mode }}" = true ]; then
-            sel=$(jq -c '{include: [.[] | select(.pr_validate)]}' .github/release-matrix.json)
+            if [ "${{ inputs.include_experimental }}" = true ]; then
+              echo "PR mode: ALL pr_validate entries (experimental included)."
+              sel=$(jq -c '{include: [.[] | select(.pr_validate)]}' \
+                      .github/release-matrix.json)
+            else
+              echo "PR mode: gating entries only (experimental excluded)."
+              sel=$(jq -c '{include: [.[] | select(.pr_validate and (.experimental | not))]}' \
+                      .github/release-matrix.json)
+              jq -r '.[] | select(.pr_validate and .experimental)
+                     | "::notice::\(.id) not built — experimental, so it cannot fail this run. Label the PR `build:distros` to build it."' \
+                .github/release-matrix.json
+            fi
             jq -r '.[] | select(.pr_validate | not)
                    | "::warning::\(.id) NOT VALIDATED in PR mode — \(.note // "toolchain \(.toolchain) unavailable on hosted runners")"' \
               .github/release-matrix.json
           else
             sel=$(jq -c '{include: .}' .github/release-matrix.json)
           fi
+          echo "selected: $(jq -r '.include | map(.id) | join(", ")' <<<"$sel")"
           echo "matrix=$sel" >> "$GITHUB_OUTPUT"
 
       - name: Summary


### PR DESCRIPTION
Reworked after review. **The original version of this PR argued from runner cost. That argument was wrong and has been withdrawn** — see below. The changes mostly survived the correction, but for different reasons, and one of them was reversed outright.

## The cost premise was wrong

The first revision claimed ~190 "billable" minutes per push after Windows 2x / macOS 10x weighting, and that this was consuming an Actions budget. It is not:

- `Atlas-Inf/atlas` is **public** (`"private": false`).
- Every runner in the tree is standard GitHub-hosted — `ubuntu-latest`, `ubuntu-24.04`, `ubuntu-24.04-arm`, `macos-14`, `windows-2022`. No larger runners, no self-hosted.
- Actions is **free** for standard runners on public repos. The 2x/10x multipliers are *private-repo* billing.

The runner-minute measurements against run `32980028273` stand; the money conclusion drawn from them does not. If cost ever becomes real here it will be because someone added larger runners or made the repo private — check those two first.

## What the constraint actually is

Concurrency and feedback latency. Public repos still sit under a concurrent-job cap, tightest by far on macOS. Observable in this repo:

- Nine workflows simultaneously queued at 17:33 on 2026-08-26.
- 4 cancelled CI runs and 2 cancelled Coverage runs in the last 100, from `cancel-in-progress` churn.
- Each push was asking for **three macOS jobs** (2 matrix entries + `test-macos-metal`) against the scarcest pool.

## The argument that replaces it: 7 of 9 builds cannot fail anything

`release-build.yml` sets each build's `continue-on-error` from its `experimental` flag. Cross-referencing `release-matrix.json`:

| entry | runner | `experimental` | gates? |
|---|---|---|---|
| `linux-x86_64-nvidia-cuda` | `ubuntu-24.04` | `false` | **yes** |
| `linux-aarch64-nvidia-cuda` | `ubuntu-24.04-arm` | `false` | **yes** |
| `linux-x86_64-nvidia-cuda-nccl` | `ubuntu-24.04` | `true` | no |
| `linux-aarch64-nvidia-cuda-nccl` | `ubuntu-24.04-arm` | `true` | no |
| `linux-x86_64-amd-scale` | `ubuntu-24.04` | `true` | no |
| `macos-aarch64-metal` | `macos-14` | `true` | no |
| `macos-x86_64-metal` | `macos-14` | `true` | no |
| `windows-x86_64-nvidia-cuda` | `windows-2022` | `true` | no |
| `windows-x86_64-amd-hip` | `windows-2022` | `true` | no |

The 34-minute Windows CUDA build — the longest job in the repository and the centrepiece of the withdrawn cost table — is `experimental: true` and is **structurally incapable of turning a PR red**. Per-push it was latency with no verdict attached.

This argues for a **split**, not the all-or-nothing deferral the first revision made.

## What this PR now does

**1. Every PR builds the two entries that can fail.** `linux-x86_64-nvidia-cuda` and `linux-aarch64-nvidia-cuda`, both native on free hosted runners, ~8 and ~5 minutes.

`linux-aarch64` is the **primary target** — GB10 / DGX Spark is arm64 Grace. The first revision deferred all nine, which removed per-PR verification of the one platform this project exists to serve. That was a mistake and is fixed here.

**2. The other seven are opt-in** via `release-build.yml`'s new `include_experimental` input, driven by a new `distros.yml` (label `build:distros`, or dispatch on any ref). `release.yml`'s existing dispatch with `dry_run: true` remains the other route and still needed no new machinery.

**3. The opt-in moved out of `ci.yml`.** ⚠️ This was a real bug in the first revision. `ci.yml`'s concurrency group is `cancel-in-progress`, so subscribing it to `pull_request: [labeled]` meant **any** label change — `bug`, `needs-rebase`, anything — would cancel an in-flight CI run and restart it from scratch. `types:` filters on the event, not on which label was applied, so it cannot be narrowed. `distros.yml` has its own concurrency group and checks `github.event.label.name` at job level, where it *is* available.

**4. Coverage is path-filtered on PRs, not removed from them.** This file's own cost note asked for exactly that and the first revision deleted the trigger instead. It is one ubuntu job and does not compete for the macOS pool.

Honest about what the filter buys: `crates/**` is where all the code lives, so **11 of the last 14 PRs still match it**. It skips docs-only, CI-only and workflow-only PRs. Worth having; not a large cut. `main` + a weekly cron still carry the trend.

**5. `test-macos-metal` stays removed** — on the concurrency argument plus the product call that Metal is not a priority right now, not on cost. ⚠️ **This is real coverage loss**: nothing verifies the Metal backend compiles during review, and `release-matrix.json` still ships macOS binaries.

The comment in its place now records the better fix if it returns: the job ran **four** compiles of the same code (`cargo check` ×2, `cargo test`, `cargo build`), and the two checks are subsumed by the build, buying only a nicer failure message for most of its ~4m41s. Collapse them rather than restoring it verbatim.

**6. Governance harvest and `pr-categorize` parked** (dispatch-only, producer/consumer pair). The harvester has never succeeded here — 11 of its last 15 runs died at `createPullRequest` because "Allow GitHub Actions to create and approve pull requests" is off. Separately, `governance/` mixes ~95 Avarok-upstream-numbered ledgers with this repo's `pr-1`…`pr-13` in one namespace, which needs untangling first. Resume instructions in both files. `harvest-triage` stays on.

**7. PR telemetry fixed.** It was rendering the full cross-PR view 40×/week and discarding it because `vars.PR_TELEMETRY_ISSUE` was never set. Created issue #15, pointed the variable at it, dispatched a run to confirm — [it posts now](https://github.com/Atlas-Inf/atlas/issues/15).

## Done outside this diff

**`cla-signatures` branch created.** CLA Assistant failed 9 of its last 10 runs with `Branch cla-signatures not found` — the signature store was never created in the move to Atlas-Inf. Orphan branch, file at `signatures/version1/cla.json` matching `cla.yml`'s `path-to-signatures`, left **unprotected** because the action commits to it directly.

## On `merge_group`

Dropped from the matrix and coverage. This is correct *given* that `main-protect` (id `21349905`) is `enforcement: disabled` with only `deletion` + `non_fast_forward` — no required checks, no merge queue. Every `merge_group` trigger in the tree is currently dead code, and seven workflows carry comments asserting they are required checks. That divergence is a known cleanup, deliberately deferred with the decision to leave enforcement off until the reds are cleared. If enforcement is switched on, restore these — a required check that never reports hangs every queue entry.

## Not in this PR

- **PR #10** (bench-gate records orphaned by the repo move) — the only systemic red, and what keeps `dev-release` skipping and the Releases page empty. Needs merging first.
- **"Allow GitHub Actions to create and approve PRs"** — one repo setting, unblocks the harvester whenever it is unparked.
- **`kernel-compile` (263 min/wk)** has no Rust caching — `apt-get` + rustup + full crate build inside the CUDA container every run, 9.4 min for work measured at 29.7s on a DGX. `Swatinem/rust-cache` should cut it hard. Path-filtering it was rejected: 4 of the last 7 human PRs touch `.cu`/`.cuh`/`atlas-kernels`.
- **The image pipeline** (GHCR canonical + Docker Hub mirror, `:sha-<7>`/`:main`/`:latest`-means-verified, manual GB10 verify + dispatched promotion). Separate work, and blocked on a `DOCKERHUB_TOKEN` secret and a decision on the Docker Hub namespace.

`actionlint` clean on all five changed files.