### PR TITLE
bench(nemotron-3.5-lightning): declare and measure the gates for the DSpark port

### DIFF
--- a/kernels/gb10/nemotron-3.5-lightning-30b-a3b/BENCH.toml
+++ b/kernels/gb10/nemotron-3.5-lightning-30b-a3b/BENCH.toml
@@ -113,10 +113,27 @@ gate = "ttft-cold-gate"
 recipe = "nemotron-3.5-lightning/nemotron-3.5-lightning-30b-a3b-nvfp4-dspark"
 label = "Nemotron-3.5-Lightning-30B-A3B (NVFP4 + DSpark)"
 default = false
-status = "unmeasured"
+status = "measured"
 note = """\
 Uncached prefill TTFT. This is the leg that sees a cold-load regression, and \
-the one to read first on a port that touched the Mamba-2 prefill path."""
+the one to read first on a port that touched the Mamba-2 prefill path. \
+FIRST MEASUREMENT, 2026-09-01, gx10-e3a3 (GB10), binary 70909412, 12 repeats per \
+prompt length: 256 tok median 508.0 / p90 511.0; 1024 tok median 905.2 / p90 \
+907.9; 4096 tok median 2647.4 / p90 2662.5. Pooled median 905.2 ms, pooled p90 \
+2648.5 ms. The gate's own verdict was `Info: no baseline on this box yet - this \
+run is recorded as the baseline`. \
+★ THE BOUNDS BELOW ARE A COARSE CEILING, NOT A CALIBRATED BAR. They are one run \
+on one box with no sigma behind them, set ~15% above the measurement so an \
+honest re-run cannot fail them. The real regression detector is this gate's own \
+median<=3% / p90<=5% comparison against its stored same-box baseline; these \
+numbers exist so the entry is not vacuous, and they should be re-taken from two \
+or more tiers before anyone treats a near-miss as a signal."""
+
+[benchmarks.metrics.median_ms]
+max = 1041.0
+
+[benchmarks.metrics.p90_ms]
+max = 3046.0
 
 [[benchmarks]]
 quant = "nvfp4"
@@ -125,7 +142,7 @@ gate = "ttft-warm-gate"
 recipe = "nemotron-3.5-lightning/nemotron-3.5-lightning-30b-a3b-nvfp4-dspark"
 label = "Nemotron-3.5-Lightning-30B-A3B (NVFP4 + DSpark)"
 default = false
-status = "unmeasured"
+status = "measured"
 note = """\
 Cached-prefix TTFT. ★ READ THE RECIPE FIRST: it pins \
 `enable_prefix_caching: false`, and not as a performance choice — the server \
@@ -134,7 +151,21 @@ warns of a community-reported correctness regression on SM12.x with DFlash \
 warm path WITHOUT the radix cache, which is a different quantity from the \
 Qwen entries' warm number and must not be compared to them. If prefix caching \
 is ever proven safe on this stack, this entry's baseline has to be retaken \
-rather than reinterpreted."""
+rather than reinterpreted. \
+FIRST MEASUREMENT, 2026-09-01, same box and binary, 12 repeats per length: 256 \
+tok median 504.5 / p90 506.1; 1024 tok median 900.8 / p90 917.5; 4096 tok median \
+2645.5 / p90 2651.9. Pooled median 900.8 ms, pooled p90 2647.8 ms. \
+★ AND THE MEASUREMENT CONFIRMS THE WARNING ABOVE: warm and cold agree to within \
+0.5% (900.8 vs 905.2 ms), and the harness reports `cached tok = 0` on every row \
+of both. Nothing was cached, because prefix caching is off by correctness pin. \
+So this entry does NOT measure a cache hit and must never be compared against a \
+recipe that caches. Same coarse-ceiling caveat as the cold entry."""
+
+[benchmarks.metrics.median_ms]
+max = 1036.0
+
+[benchmarks.metrics.p90_ms]
+max = 3045.0
 
 [[benchmarks]]
 quant = "nvfp4"
@@ -158,7 +189,17 @@ the BENCH — never the server — when MemAvailable drops below ~1.2 GB, and do
 not raise the utilisation without re-measuring. The dip at C=6 reproduces and \
 is unexplained; it fails nothing. Those numbers came from an ad-hoc ladder, \
 not from this gate, so they are context for whoever reads the first record — \
-not a threshold, and not a baseline."""
+not a threshold, and not a baseline. \
+★ MEASURED 2026-09-01 ON THIS GATE, 24 cells (ISL 128/512/1024/2048 x C \
+1/2/4/8/16/32), verdict `Info: 24 cells, no request errors, all above the \
+vacuity floor`. The shape, at ISL 128: TTFT p50 600 ms -> 4.42 s -> 41.1 s at \
+C=1 -> 8 -> 32, TPOT p50 12.4 -> 114.1 -> 120.6 ms, and SERVER decode flat at \
+58.5 -> 52.8 -> 53.3 tok/s. Read that carefully: the table's `tok/s` column is \
+the server-side decode rate, not aggregate throughput, so its peak at C=1 is \
+arithmetic and not a scaling failure. Decode rate is flat across every rung and \
+every ISL while TTFT degrades ~68x, which is what `max_batch_size: 8` predicts - \
+at C=16 and C=32 requests are QUEUEING, not batching. Still no thresholds: this \
+gate is not required and a curve is not a bound."""
 
 # ── The correctness gate the DSpark verify path most needs ──────────────────
 [[benchmarks]]
@@ -181,4 +222,16 @@ recurrent state is precisely what this gate detects, and it detects it as \
 byte-difference in a replayed conversation rather than as a wrong number. \
 `collapsed` and `unmeasured` take zero tolerance when thresholds are set; \
 `jittered` must NOT be bounded, because restore-anchor selection varies \
-between rounds on a healthy engine."""
+between rounds on a healthy engine. \
+★ ATTEMPTED 2026-09-01 AND IT COULD NOT EVALUATE THIS CHECKPOINT AT ALL. The \
+gate failed on its REFERENCE round, not on a replay: \
+`reference round failed the script anchors (turn 2: line 1 does not start with \
+its number ...) - replays compared against it would certify nothing`. The model \
+does not emit the numbered-line format the gate's script requires, so there is \
+no valid reference to compare replays against. NOTHING ABOUT SSM POISONING WAS \
+TESTED - this is not a pass and it is not a failure of the rollback path; it is \
+the gate being unable to run. That matters more here than on any other target, \
+because this is the gate the DSpark merge most needs. Probably downstream of \
+this model's thinking_default = true, which the recipe deliberately does not \
+override. Fixing it needs a model-appropriate prompt or a thinking-aware \
+extractor."""

--- a/kernels/gb10/nemotron-3.5-lightning-30b-a3b/BENCH.toml
+++ b/kernels/gb10/nemotron-3.5-lightning-30b-a3b/BENCH.toml
@@ -105,9 +105,30 @@ CONCLUSION: the generation half demonstrably works and the failure is \
 somewhere in the generation-to-AST-scoring handoff. The exact mechanism is NOT \
 identified. So this run neither certifies nor condemns the DSpark port, the \
 entry stays `unmeasured`, and NO THRESHOLD IS SET FROM 11.26 - a bar taken \
-from a number this contradicted would be worse than no bar. What would settle \
-it: dump the responses file the Rust driver hands the Python checker and score \
-one simple_python sample by hand."""
+from a number this contradicted would be worse than no bar. LOCALISED 2026-09-01, after dumping that file. \
+`~/.atlas/artifacts/bfcl/responses.jsonl` (the driver keeps it so a run can be \
+rescored) holds 995 lines and EVERY ONE reads \
+`"has_tool_calls": false, "tool_calls": []`. So the Python AST checker scored \
+faithfully what it was handed - the loss is upstream of scoring, in the \
+GENERATION half of the driver. Ruled out, each by direct experiment on this \
+same server: DSpark (identical call with --dflash and with speculation off); \
+streaming (the SSE deltas carry index 0 with id/type/name then incremental \
+`arguments`, terminating finish_reason "tool_calls"); BFCL's non-JSON-Schema \
+`{"type":"dict"}` parameter shape (schema.rs normalises dict->object and the \
+call still comes back correct); tool grammar (--disable-tool-grammar true \
+changes nothing); and request construction (the driver sends tool_choice auto, \
+temperature 0.0, max_tokens 1024 - equivalent to the hand-sent request). The \
+control is exact: the dataset's own first sample, calculate_triangle_area with \
+base 10 and height 5, returns a correct well-formed call when sent by hand to \
+this server. \
+WHAT IS LEFT is the one thing not controlled for - `atlas_plugin::http::\
+chat_stream`, a hand-rolled TCP + SSE client, where the by-hand control used \
+curl. That is where to look next; the accumulator in http.rs:217 reads correct \
+and has a passing unit test, so suspect the transport/chunk framing above it \
+rather than the delta merge itself. NOT PROVEN, but every alternative that \
+could be tested has been eliminated. \
+★ THE CONSEQUENCE FOR THIS PORT: ST-995 does not implicate DSpark. Tool calling \
+on this checkpoint works."""
 
 # ── The perf leg ────────────────────────────────────────────────────────────
 # decode-floor, the two TTFT guards and the concurrency sweep, run as one set.

--- a/kernels/gb10/nemotron-3.5-lightning-30b-a3b/BENCH.toml
+++ b/kernels/gb10/nemotron-3.5-lightning-30b-a3b/BENCH.toml
@@ -82,7 +82,32 @@ cap_thinking_at_max_tokens = false). Do NOT pass --disable-thinking to make \
 the numbers look tidier: with thinking forced off this model returns null \
 content on multi-turn tool follow-ups, which would corrupt exactly the \
 category BFCL scores. The recipe leaves the model default in place and this \
-entry is defined on that."""
+entry is defined on that. \
+★ RAN 2026-09-01 AND THE RESULT IS NOT USABLE AS A SCORE. overall_accuracy \
+11.26, normalized_single_turn_score 33.33, n=995, 995/995 samples, ZERO \
+transport failures, 3945 s wall. The category breakdown is the tell: \
+hallucination 100.00, live 0.00, non_live 0.00, and every non_live \
+subcategory 0.00 including simple_python. Scoring 100 on the one category \
+whose correct behaviour is NOT to call a tool, and exactly 0 on every category \
+that requires one, is the shape of "no call was ever scored as present". \
+★ THAT IS CONTRADICTED BY DIRECT MEASUREMENT ON THIS EXACT CONFIGURATION. A \
+single-tool request returns a correct, well-formed call - \
+finish_reason=tool_calls, name=get_current_weather, \
+arguments={"location":"San Francisco, CA","unit":"celsius"} - and it does so \
+identically with DSpark ON and with speculation OFF, and over BOTH the \
+non-streaming and the streaming path that the BFCL driver actually uses. The \
+streamed deltas are textbook OpenAI shape: index 0 carrying id/type/name, then \
+incremental `arguments` fragments, terminating with \
+finish_reason "tool_calls". The parser is live and auto-detected \
+(`Tool call parser: qwen3_coder (auto-detected from model_type)`) and the \
+server logged tools_active=true on all 367 tool-bearing requests of the run. \
+CONCLUSION: the generation half demonstrably works and the failure is \
+somewhere in the generation-to-AST-scoring handoff. The exact mechanism is NOT \
+identified. So this run neither certifies nor condemns the DSpark port, the \
+entry stays `unmeasured`, and NO THRESHOLD IS SET FROM 11.26 - a bar taken \
+from a number this contradicted would be worse than no bar. What would settle \
+it: dump the responses file the Rust driver hands the Python checker and score \
+one simple_python sample by hand."""
 
 # ── The perf leg ────────────────────────────────────────────────────────────
 # decode-floor, the two TTFT guards and the concurrency sweep, run as one set.

--- a/kernels/gb10/nemotron-3.5-lightning-30b-a3b/BENCH.toml
+++ b/kernels/gb10/nemotron-3.5-lightning-30b-a3b/BENCH.toml
@@ -1,0 +1,184 @@
+# Benchmarks for Nemotron-3.5-Lightning-30B-A3B, and the thresholds its gate
+# records must meet.
+#
+# ★ EVERY ENTRY HERE IS `status = "unmeasured"`. This model has never been
+# gated: before this file, no Nemotron target in the tree carried a BENCH.toml
+# at all, so there is no committed history to ratchet from and no bar this
+# checkpoint has ever cleared. An unmeasured entry carries NO
+# [benchmarks.metrics] table on purpose — per the header of
+# kernels/gb10/qwen3.8-27b/BENCH.toml, a guessed threshold a run could clear
+# would report PASS for something nobody measured. These entries BASELINE.
+# Thresholds land in a follow-up commit, taken from the records these runs
+# write, and that commit is where the gate starts to mean something.
+#
+# ★ AN UNMEASURED ENTRY CANNOT SELF-START, AND THAT IS BY DESIGN. `--pull-
+# request-gate` resolves through gate::bench::baseline_for, which SKIPS every
+# entry whose status is not "measured" and every entry with no metrics table —
+# so these six are invisible to it and a gate run refuses with "no baseline for
+# model X", which the code calls the honest answer. The first pass therefore
+# runs against an operator-started server:
+#
+#   ATLAS_DFLASH_OPTION_B=1 spark serve <target> --no-tui --port 8899 \
+#     <the recipe's defaults, verbatim>
+#   spark benchmark run <gate> --url http://127.0.0.1:8899 \
+#     --model nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4 \
+#     --no-fail-on-verdict --format json
+#
+# That produces numbers in ~/.atlas/runs but NO committed record. The second
+# pass — thresholds set from those numbers, status flipped to "measured", the
+# cheap gates re-run under --pull-request-gate — is what writes .benchmarks/
+# and what makes any of this a gate rather than a measurement.
+#
+# ★ NOTHING HERE IS `default = true`. The default subject of each of these
+# gates is already claimed by a Qwen target (bfcl-subset, decode-floor and
+# concurrency-sweep by qwen3.8-27b; the two TTFT guards and
+# ssm-state-poisoning-gate by qwen3.6-35b-a3b), and two defaults refuse to
+# assemble at all. Select this checkpoint explicitly:
+#
+#   ATLAS_DFLASH_OPTION_B=1 spark benchmark run <gate> --pull-request-gate \
+#     --hardware gb10 \
+#     --checkpoint nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4
+#
+# ★ ATLAS_DFLASH_OPTION_B=1 IS REQUIRED and cannot live in the recipe. The
+# Lightning DSpark product policy (dflash_head/product_policy.rs::validate)
+# refuses to start without it, and refuses to start if any DSpark diagnostic
+# toggle is set. The recipe schema has no `env:` key, so it must be exported by
+# whoever starts the gate; a gate run without it fails at boot, not at verdict.
+#
+# ★ THE COHERENCE PROBE WILL WARN, and the warning is correct. bfcl-subset's
+# descriptor declares `intended_for` families qwen3.6-27b / qwen3.6-35b-a3b /
+# qwen3.8-27b, so a run here reports `wrong_family`. The probe only warns and
+# never refuses (ModelExpectation feeds coherence::probe_for, not a veto), and
+# the warning is the honest reading: this checkpoint has no recorded BFCL
+# baseline anywhere, which is exactly what these entries exist to create. Do
+# not silence it by widening the descriptor's family list until a measured
+# baseline exists to justify the claim.
+
+# ── ST-995: the golden n=995 MLPerf-edge BFCL draw ──────────────────────────
+# The single-turn tool-calling leg. It is the gate that matters for the DSpark
+# port specifically: the drafter changes proposal numerics and therefore
+# acceptance, and a speculative path that is subtly wrong shows up as
+# tool-argument damage long before it shows up as incoherence. Scores here are
+# NOT comparable to the qwen3.6-27b entry's MLPerf floor (83.64 / 85.32) — same
+# draw, different architecture and different weights — and this entry
+# deliberately inherits neither that floor nor any Qwen bar.
+[[benchmarks]]
+quant = "nvfp4"
+checkpoint = "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4"
+gate = "bfcl-subset"
+recipe = "nemotron-3.5-lightning/nemotron-3.5-lightning-30b-a3b-nvfp4-dspark"
+label = "Nemotron-3.5-Lightning-30B-A3B (NVFP4 + DSpark)"
+default = false
+status = "unmeasured"
+note = """\
+FIRST BFCL measurement on any Nemotron target. The recipe serves DSpark, not \
+Atlas MTP: `--dflash` with the published 6-layer Qwen3DSparkModel drafter at \
+gamma=4 (the server derives num_drafts=3 from it), NOT `--speculative`, and \
+the two flags are mutually exclusive. That is the configuration under test — \
+running BFCL on this model without the drafter would measure a different \
+engine path and say nothing about the port. \
+★ THINKING IS ON, by the model's own MODEL.toml (thinking_default = true, \
+cap_thinking_at_max_tokens = false). Do NOT pass --disable-thinking to make \
+the numbers look tidier: with thinking forced off this model returns null \
+content on multi-turn tool follow-ups, which would corrupt exactly the \
+category BFCL scores. The recipe leaves the model default in place and this \
+entry is defined on that."""
+
+# ── The perf leg ────────────────────────────────────────────────────────────
+# decode-floor, the two TTFT guards and the concurrency sweep, run as one set.
+# All four are speed measurements, so all four are hostage to the box: a GB10
+# that throttles mid-run marks its own record INVALID (hardware_state.postcheck)
+# and those numbers must not be quoted. Check that flag on every record before
+# ratcheting a threshold from it.
+[[benchmarks]]
+quant = "nvfp4"
+checkpoint = "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4"
+gate = "decode-floor"
+recipe = "nemotron-3.5-lightning/nemotron-3.5-lightning-30b-a3b-nvfp4-dspark"
+label = "Nemotron-3.5-Lightning-30B-A3B (NVFP4 + DSpark)"
+default = false
+status = "unmeasured"
+note = """\
+Median-of-3 server decode rate. On this target it is really a DSpark \
+acceptance measurement wearing a decode-rate hat: the drafter proposes gamma=4 \
+and the target verifies K=3 in one batched step, so the decode number moves \
+with acceptance, and an acceptance regression that leaves output correct still \
+shows up here. Record `output_tokens` and `runs` alongside it — a fast median \
+over runs that decoded almost nothing is not a floor."""
+
+[[benchmarks]]
+quant = "nvfp4"
+checkpoint = "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4"
+gate = "ttft-cold-gate"
+recipe = "nemotron-3.5-lightning/nemotron-3.5-lightning-30b-a3b-nvfp4-dspark"
+label = "Nemotron-3.5-Lightning-30B-A3B (NVFP4 + DSpark)"
+default = false
+status = "unmeasured"
+note = """\
+Uncached prefill TTFT. This is the leg that sees a cold-load regression, and \
+the one to read first on a port that touched the Mamba-2 prefill path."""
+
+[[benchmarks]]
+quant = "nvfp4"
+checkpoint = "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4"
+gate = "ttft-warm-gate"
+recipe = "nemotron-3.5-lightning/nemotron-3.5-lightning-30b-a3b-nvfp4-dspark"
+label = "Nemotron-3.5-Lightning-30B-A3B (NVFP4 + DSpark)"
+default = false
+status = "unmeasured"
+note = """\
+Cached-prefix TTFT. ★ READ THE RECIPE FIRST: it pins \
+`enable_prefix_caching: false`, and not as a performance choice — the server \
+warns of a community-reported correctness regression on SM12.x with DFlash \
+(wrong output on multi-turn cache hits). So the warm guard here measures the \
+warm path WITHOUT the radix cache, which is a different quantity from the \
+Qwen entries' warm number and must not be compared to them. If prefix caching \
+is ever proven safe on this stack, this entry's baseline has to be retaken \
+rather than reinterpreted."""
+
+[[benchmarks]]
+quant = "nvfp4"
+checkpoint = "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4"
+gate = "concurrency-sweep"
+recipe = "nemotron-3.5-lightning/nemotron-3.5-lightning-30b-a3b-nvfp4-dspark"
+label = "Nemotron-3.5-Lightning-30B-A3B (NVFP4 + DSpark)"
+default = false
+status = "unmeasured"
+note = """\
+The C=1..32 ladder. ★ THE RECIPE'S `gpu_memory_utilization: 0.80` IS LOAD- \
+BEARING FOR THIS GATE AND IS NOT A TUNING KNOB. Measured on a GB10 (119 GB \
+unified) 2026-08-26: at 0.88 the box has ~6 GB of host memory left once the \
+model is resident and concurrency 8 exhausts it between consecutive samples of \
+a 2-second poll — 6.4 GB to 180 MB — taking the machine off the network \
+entirely, with no reboot. At 0.80 the post-load headroom is ~15.8 GB and the \
+1/2/4/6/8 ladder completes with zero failed requests: 76.1 / 95.8 / 120.6 / \
+104.1 / 140.3 aggregate tok/s, 1.84x at C8, 17.6 tok/s per client. That is a \
+CLIFF, not a gradient. Run this sweep behind a host-memory watchdog that kills \
+the BENCH — never the server — when MemAvailable drops below ~1.2 GB, and do \
+not raise the utilisation without re-measuring. The dip at C=6 reproduces and \
+is unexplained; it fails nothing. Those numbers came from an ad-hoc ladder, \
+not from this gate, so they are context for whoever reads the first record — \
+not a threshold, and not a baseline."""
+
+# ── The correctness gate the DSpark verify path most needs ──────────────────
+[[benchmarks]]
+quant = "nvfp4"
+checkpoint = "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4"
+gate = "ssm-state-poisoning-gate"
+recipe = "nemotron-3.5-lightning/nemotron-3.5-lightning-30b-a3b-nvfp4-dspark"
+label = "Nemotron-3.5-Lightning-30B-A3B (NVFP4 + DSpark)"
+default = false
+status = "unmeasured"
+note = """\
+Declared because this port has a specific reason to fear it, not because the \
+set looked incomplete. The merge that brought DSpark here combined two \
+rollback implementations in `verify_a.rs` / `async_chkpt.rs`: upstream's \
+`ssm_pool.h_stored_bytes` for h_bytes with the ported \
+`config.ssm_conv_state_bytes()` for conv_bytes — because the GDN formula \
+(nk*kd*2 + nv*vd) evaluates to 0 on a Nemotron-H backbone, which left LIVE SSM \
+state behind on rejected drafts. A speculative decoder that fails to roll back \
+recurrent state is precisely what this gate detects, and it detects it as \
+byte-difference in a replayed conversation rather than as a wrong number. \
+`collapsed` and `unmeasured` take zero tolerance when thresholds are set; \
+`jittered` must NOT be bounded, because restore-anchor selection varies \
+between rounds on a healthy engine."""


### PR DESCRIPTION
Stacked on **#12** (`port/dspark-gb10-sm121`), which this measures. Two commits: declare
the gates, then fill in what ran.

Before this, **no Nemotron target in the tree carried a `BENCH.toml` at all**, so nothing
about the DSpark port was gateable — `gate/check.rs` refuses an entry with no thresholds
rather than passing it vacuously, and there was no entry to refuse. This adds
`kernels/gb10/nemotron-3.5-lightning-30b-a3b/BENCH.toml` with six entries, all
`default = false` (each of these gates already has a Qwen default, and two defaults refuse
to assemble).

## The port itself

Builds clean at `70909412` with `--no-default-features --features cuda` (NCCL is a default
feature and `libnccl` is absent on a single-box Spark). Kernel preflight passes:
`(nemotron-3.5-lightning-30b-a3b, sm_121, nvfp4)` — **183 lookups, 0 unresolved**, 11
declared expected-absent, kernel-set hash `4e5436582619`.

DSpark is the **active proposer**, not merely loaded:

```
Lightning DSpark drafter installed as the active proposer
DFlash speculative decoding: ENABLED (γ=4, window=1024, drafter installed)
Scheduler started (batched mode, max_batch=8, mtp=true, num_drafts=3, policy=slai)
```

and under concurrency the batched verify path engages —
`DFLASH WIDTH n_active=4 verify=4 dspark_batch_ok=true ladder_nd=3`.

## The perf leg

| gate | result | status here |
|---|---|---|
| `ttft-cold-gate` | pooled median **905.2 ms**, p90 2648.5 (12×3 lengths) | `measured`, bounds set |
| `ttft-warm-gate` | pooled median **900.8 ms**, p90 2647.8 | `measured`, bounds set |
| `decode-floor` | **65.9 / 66.0 / 65.9** tok/s, 175 of 259 accepted | `unmeasured` — gate says INCONCLUSIVE |
| `concurrency-sweep` | 24 cells, **zero errors** | `unmeasured` — no thresholds by design |
| `ssm-state-poisoning-gate` | — | `unmeasured` — **could not run** |
| `bfcl-subset` (ST-995) | running (~3.5 h) | lands separately |

**Warm and cold agree to within 0.5% and `cached tok` is 0 on every row.** That is the
recipe's `enable_prefix_caching: false` behaving as documented — a correctness pin against
the community-reported SM12.x DFlash multi-turn wrong-output regression, not a perf knob.
So this warm entry does not measure a cache hit and must never be compared against a
recipe that caches.

**The concurrency shape**, at ISL 128: TTFT p50 600 ms → 4.42 s → 41.1 s at C=1 → 8 → 32,
TPOT p50 12.4 → 114.1 → 120.6 ms, and *server* decode flat at 58.5 → 52.8 → 53.3 tok/s.
The table's `tok/s` column is server-side decode, not aggregate, so its peak at C=1 is
arithmetic rather than a scaling failure. Decode is flat across every rung while TTFT
degrades ~68×, which is what `max_batch_size: 8` predicts: C=16 and C=32 queue.

## Two gates cannot evaluate this checkpoint, and neither failure is the port's

- **`decode-floor` → `INCONCLUSIVE`.** The model answers the gate's fixed prompt in 259
  tokens, against a 750-token vacuity floor that is a constant in `decode_floor/score.rs`,
  not a `--param`. The three speed numbers are clean and 0.15% apart; the gate will not
  ratify a floor measured over a decode that short. Left `unmeasured` on purpose — a bound
  taken from a run the gate itself refused to certify would read green off nothing.
- **`ssm-state-poisoning-gate` → failed its REFERENCE round**, not a replay: the model does
  not emit the numbered-line format the script anchors require, so "replays compared
  against it would certify nothing". **Nothing about SSM poisoning was tested.** That is
  the gate this merge most needs — it combined two rollback implementations, and the GDN
  `conv_bytes` formula evaluates to 0 on a Nemotron-H backbone, which left live SSM state
  on rejected drafts. Worth fixing first.

Both are probably downstream of this model's `thinking_default = true`, which the recipe
deliberately does not override (forced off, multi-turn tool follow-ups return null
`content`). Fixing them needs model-appropriate prompts or a thinking-aware extractor, not
a recipe change.

## How these were run, and why not under `--pull-request-gate`

`gate::bench::baseline_for` skips every entry whose `status` is not `"measured"`, so a
brand-new target is invisible to the gate and it refuses with "no baseline for model X" —
which the code calls the honest answer. First measurements therefore have to run against
an operator-started server over `--url`. These did, serving the recipe's `defaults:`
verbatim with `ATLAS_DFLASH_OPTION_B=1` (required — `product_policy.rs::validate` refuses
to boot without it, and the recipe schema has no `env:` key to carry it). That is why there
are no `.benchmarks/` records in this PR: the numbers are real, the committed-record path
needs the thresholds this PR adds, which is the next run's job.

Recipe: Atlas-Inf/sparkrun-recipes#1.
