### PR TITLE
bench: point the 27B gates at nvidia/Qwen3.8-27B-NVFP4 and recalibrate the vacuity pin

### DIFF
--- a/crates/atlas-plugin/src/benchmarks/decode_floor/decode_floor_tests.rs
+++ b/crates/atlas-plugin/src/benchmarks/decode_floor/decode_floor_tests.rs
@@ -45,6 +45,9 @@ fn three_healthy_runs_measure_the_median() {
 fn min_output_tokens_is_the_worst_run_not_the_mean() {
     let mut samples = [healthy(30.0), healthy(30.0), healthy(30.0)];
     samples[1].completion_tokens = MIN_OUTPUT_TOKENS; // exactly at the floor: still valid
+    // …but the accept accounting still has to be sane at that width: accepted
+    // must stay strictly below completion or the run is corrupt, not measured.
+    samples[1].accepted_prediction_tokens = Some(MIN_OUTPUT_TOKENS / 2);
     match evaluate(&samples) {
         Evaluation::Measured {
             min_output_tokens, ..
@@ -58,7 +61,7 @@ fn min_output_tokens_is_the_worst_run_not_the_mean() {
 #[test]
 fn output_floor_is_inclusive_and_one_below_is_inconclusive() {
     let mut samples = [healthy(30.0), healthy(30.0), healthy(30.0)];
-    samples[2].completion_tokens = MIN_OUTPUT_TOKENS - 1; // 799
+    samples[2].completion_tokens = MIN_OUTPUT_TOKENS - 1; // 699
     match evaluate(&samples) {
         Evaluation::Inconclusive(why) => {
             assert!(why.contains("run 3"), "{why}");
@@ -273,9 +276,10 @@ fn the_floor_param_is_wired_to_the_gate() {
 fn the_pins_are_the_documented_fingerprint() {
     assert_eq!(RUNS, 3);
     assert_eq!(MAX_TOKENS, 1500);
-    // 750 since the 2026-08-15 promotion calibration: the instrument's
-    // deterministic natural stop is 915, and the pin must sit under it.
-    assert_eq!(MIN_OUTPUT_TOKENS, 750);
+    // 700: the served subject (nvidia/Qwen3.8-27B-NVFP4) stops at a
+    // deterministic 717-718, so the pin must sit under THAT, not the unsloth
+    // checkpoint's 915.
+    assert_eq!(MIN_OUTPUT_TOKENS, 700);
     assert_eq!(MIN_ACCEPT_LEN, 1.5);
     assert!(MINHEAP_PROMPT.contains("MinHeap"));
 }

--- a/crates/atlas-plugin/src/benchmarks/decode_floor/mod.rs
+++ b/crates/atlas-plugin/src/benchmarks/decode_floor/mod.rs
@@ -36,8 +36,8 @@
 //! makes the run INCONCLUSIVE (rendered as a failing verdict, like the video
 //! gate's — a run that measured nothing must not read as green):
 //!
-//! * every run's `completion_tokens >= 800` (of the 1500 cap — the calibrated
-//!   instrument's deterministic natural stop is 915, see `MIN_OUTPUT_TOKENS`);
+//! * every run's `completion_tokens >= 700` (of the 1500 cap — the served
+//!   subject's deterministic natural stop is 717-718, see `MIN_OUTPUT_TOKENS`);
 //! * every run reports the server decode rate (`usage."response_token/s"`);
 //! * `accept_len_mean >= 1.5`, derived from
 //!   `usage.completion_tokens_details.accepted_prediction_tokens` — the
@@ -80,8 +80,8 @@ pub const DESCRIPTOR: BenchmarkDescriptor = BenchmarkDescriptor {
              MEDIAN server decode rate (usage.\"response_token/s\"), judged against the \
              BENCH.toml floor under --pull-request-gate. Vacuity pins make the run \
              INCONCLUSIVE rather than PASS when it measured nothing: every run must emit \
-             >=800 of the 1500-token budget (the calibrated instrument's natural stop is a \
-             deterministic 915), report the server rate, and show accept_len_mean >= 1.5 \
+             >=700 of the 1500-token budget (the served subject's natural stop is a \
+             deterministic 717-718), report the server rate, and show accept_len_mean >= 1.5 \
              derived from usage.completion_tokens_details.accepted_prediction_tokens \
              (requires the accept-stats instrumentation; a serve that is not speculating \
              cannot pass this gate's floor honestly). REQUIRED since 2026-08-15, promoted \

--- a/crates/atlas-plugin/src/benchmarks/decode_floor/score.rs
+++ b/crates/atlas-plugin/src/benchmarks/decode_floor/score.rs
@@ -16,17 +16,16 @@ pub(crate) const RUNS: usize = 3;
 pub(crate) const MAX_TOKENS: usize = 1500;
 /// Vacuity floor on every run's `completion_tokens`.
 ///
-/// ★ 750, not 1200 — recalibrated to the gate's own instrument at promotion
-/// (2026-08-15). The 12-run calibration (temp 0 / seed 0, this fixture)
-/// completes at a DETERMINISTIC 915 tokens of the 1500 budget: the model's
-/// natural stop for the MinHeap task, identical every run. The original 1200
-/// floor predated that measurement and would have made the calibrated
-/// instrument INCONCLUSIVE by construction — a gate that fails its own
-/// reference behaviour deterministically gates nothing. 750 keeps the pin's
-/// purpose (a 49-token burst can never read as a decode measurement) while
-/// sitting safely under the instrument's natural 915 with margin for small
-/// completion-length drift.
-pub(crate) const MIN_OUTPUT_TOKENS: usize = 750;
+/// ★ 700, not 1200 — the same rule applied to the CURRENT subject. The gate
+/// serves nvidia/Qwen3.8-27B-NVFP4, whose natural stop for the MinHeap task is
+/// a deterministic 717-718 tokens of the 1500 budget (measured 2026-09-11/12
+/// across the gate's own driver), against the unsloth checkpoint's 915. A pin
+/// above a subject's own reference behaviour fails every honest run by
+/// construction — a gate that cannot pass its own instrument gates nothing —
+/// so the pin sits under the narrower of the two stops with margin for small
+/// completion-length drift, while still refusing a 49-token burst as a decode
+/// measurement.
+pub(crate) const MIN_OUTPUT_TOKENS: usize = 700;
 /// Vacuity floor on the derived tokens-per-decode-step.
 pub(crate) const MIN_ACCEPT_LEN: f64 = 1.5;
 

--- a/kernels/gb10/qwen3.8-27b/BENCH.toml
+++ b/kernels/gb10/qwen3.8-27b/BENCH.toml
@@ -26,7 +26,7 @@ quant = "nvfp4"
 checkpoint = "nvidia/Qwen3.8-27B-NVFP4"
 gate = "agentic-webserver"
 recipe = "qwen3.8/qwen3.8-27b-nvfp4-unsloth"
-label = "Qwen3.8-27B dense (NVFP4, unsloth)"
+label = "Qwen3.8-27B dense (NVFP4, nvidia)"
 # NOT the default: the required Gate A subject stays the 35B MoE flagship
 # (qwen3.6-35b-a3b/BENCH.toml), whose recorded history is untouched. This
 # variant runs via `--checkpoint unsloth/Qwen3.8-27B-NVFP4`, or from the TUI's
@@ -109,7 +109,7 @@ quant = "nvfp4"
 checkpoint = "nvidia/Qwen3.8-27B-NVFP4"
 gate = "bfcl-subset"
 recipe = "qwen3.8/qwen3.8-27b-nvfp4-unsloth-bfcl"
-label = "Qwen3.8-27B dense (NVFP4, unsloth)"
+label = "Qwen3.8-27B dense (NVFP4, nvidia)"
 # THE REQUIRED bfcl-subset SUBJECT as of 2026-08-15 (flipped from Qwen3.6-27B per
 # maintainer: 3.6 is no longer worth requiring on every PR). The 3.6 entry in
 # kernels/gb10/qwen3.6-27b/BENCH.toml is now default = false — see the consequence
@@ -190,32 +190,30 @@ quant = "nvfp4"
 checkpoint = "nvidia/Qwen3.8-27B-NVFP4"
 gate = "decode-floor"
 recipe = "qwen3.8/qwen3.8-27b-nvfp4-unsloth"
-label = "Qwen3.8-27B dense (NVFP4, unsloth)"
+label = "Qwen3.8-27B dense (NVFP4, nvidia)"
 default = true
 status = "measured"
 note = """\
-CALIBRATED 2026-08-15, dgx1, this branch's binary: n=12 runs across 4 driver \
-passes, every run 28.0-28.1 tok/s, mean 28.03, sigma ~0.05. Fingerprint (the \
-instrument these bounds belong to): the DRIVER'S OWN MinHeap fixture, \
-per-request reasoning_effort "none", temperature 0, seed 0, max_tokens 1500 \
-with a deterministic 915-token natural stop, K4 num_drafts=3 (the recipe \
-pins num_drafts: 3), accepted 569/915 per run, serve --max-batch-size 32 \
---gpu-memory-utilization 0.85 (the stock recipe serve). ★ SUPERSEDED BASIS, \
-kept for the history: the previous floor (29.0, noise 1.0) came from an n=3 \
-basis of 31.5/29.6/30.5 (median 30.5), 2026-08-15 — measured with a \
-DIFFERENT instrument (batch-1 serve, an ad-hoc probe prompt, not the \
-driver's fixture). Mechanism of the shift: different fixture + serve config \
-moved the LEVEL by -2.4 tok/s while run-to-run sigma on the fixed instrument \
-is 0.05 — an instrument change, not a regression. The gate is calibrated to \
-ITS OWN instrument; never mix bases, and never ratchet from a best run. \
-★ The gate serve needs NO operator flags for thinking: thinking-off arrives \
-per-request (reasoning_effort "none" in the body — honored since the \
-medium-default change), NOT from the recipe, so the stock recipe serve is \
-the correct subject. ★ The accept pin depends on the accept-stats \
-instrumentation (real accepted_prediction_tokens in usage); a binary \
-without it reports INCONCLUSIVE by name, which is correct — a floor \
-measured without proof of speculative engagement is the 2026-08-15 decode \
-flip-flop all over again."""
+CALIBRATED 2026-08-15 on unsloth/Qwen3.8-27B-NVFP4 (dgx1): n=12 across 4 driver \
+passes, every run 28.0-28.1 tok/s, mean 28.03, sigma ~0.05. Fingerprint: the \
+DRIVER'S OWN MinHeap fixture, per-request reasoning_effort "none", temperature \
+0, seed 0, max_tokens 1500, K4 num_drafts=3, serve --max-batch-size 32 \
+--gpu-memory-utilization 0.85 (the stock recipe serve). ★ 2026-09-11/12 RE-BASED \
+on the CURRENT subject, nvidia/Qwen3.8-27B-NVFP4 (reiner, GB10, driver \
+580.126.09, 4 driver passes = 12 runs): per-run 26.1-27.1 tok/s, median \
+26.1-26.3, sigma ~0.36; natural stop 717-718 of the 1500 budget against \
+unsloth's 915 — which is why MIN_OUTPUT_TOKENS moved to 700; accept_len_mean \
+2.77. The rate floor is RETAINED at 21.0 (mean minus ~5, far outside the ~0.4 \
+sigma band) rather than ratcheted: a tighter floor is derivable from this basis \
+but has not been agreed. ★ The checkpoint moved because the unsloth build keeps \
+BOTH an FP8 copy (prefill GEMM) and an NVFP4 copy (decode) for its 303 ignored \
+modules — 29.98 GB of layer construction against 15.85 GB — and at this serve \
+that is 59.5 GB pre-KV + 43.0 GB reserve against a 101.7 GB budget, i.e. it \
+cannot serve at all. ★ The gate serve needs NO operator flags for thinking: \
+thinking-off arrives per-request (reasoning_effort "none" in the body), NOT from \
+the recipe. ★ The accept pin depends on the accept-stats instrumentation (real \
+accepted_prediction_tokens in usage); a binary without it reports INCONCLUSIVE \
+by name, which is correct."""
 
 [benchmarks.metrics.server_decode_tok_s]
 # Median-of-3 server decode rate, judged against the 12-run calibration:
@@ -269,7 +267,7 @@ quant = "nvfp4"
 checkpoint = "nvidia/Qwen3.8-27B-NVFP4"
 gate = "concurrency-sweep"
 recipe = "qwen3.8/qwen3.8-27b-nvfp4-unsloth"
-label = "Qwen3.8-27B dense (NVFP4, unsloth)"
+label = "Qwen3.8-27B dense (NVFP4, nvidia)"
 default = true
 status = "measured"
 note = """\
@@ -494,7 +492,7 @@ quant = "nvfp4"
 checkpoint = "nvidia/Qwen3.8-27B-NVFP4"
 gate = "vision-fidelity"
 recipe = "qwen3.8/qwen3.8-27b-nvfp4-unsloth"
-label = "Qwen3.8-27B dense (NVFP4, unsloth)"
+label = "Qwen3.8-27B dense (NVFP4, nvidia)"
 default = false
 status = "measured"
 note = """\
@@ -618,7 +616,7 @@ quant = "nvfp4"
 checkpoint = "nvidia/Qwen3.8-27B-NVFP4"
 gate = "video-fidelity"
 recipe = "qwen3.8/qwen3.8-27b-nvfp4-unsloth"
-label = "Qwen3.8-27B dense (NVFP4, unsloth)"
+label = "Qwen3.8-27B dense (NVFP4, nvidia)"
 # `default = false` since 2026-08-15: qwen3.6-27b owns this gate's required
 # subject. Not a demotion of the checkpoint and not a lowered bar -- the
 # thresholds below are unchanged and this entry is still measured whenever it

--- a/kernels/gb10/qwen3.8-27b/BENCH.toml
+++ b/kernels/gb10/qwen3.8-27b/BENCH.toml
@@ -23,7 +23,7 @@
 
 [[benchmarks]]
 quant = "nvfp4"
-checkpoint = "unsloth/Qwen3.8-27B-NVFP4"
+checkpoint = "nvidia/Qwen3.8-27B-NVFP4"
 gate = "agentic-webserver"
 recipe = "qwen3.8/qwen3.8-27b-nvfp4-unsloth"
 label = "Qwen3.8-27B dense (NVFP4, unsloth)"
@@ -106,7 +106,7 @@ min = 10.0
 
 [[benchmarks]]
 quant = "nvfp4"
-checkpoint = "unsloth/Qwen3.8-27B-NVFP4"
+checkpoint = "nvidia/Qwen3.8-27B-NVFP4"
 gate = "bfcl-subset"
 recipe = "qwen3.8/qwen3.8-27b-nvfp4-unsloth-bfcl"
 label = "Qwen3.8-27B dense (NVFP4, unsloth)"
@@ -187,7 +187,7 @@ noise = 0.4
 
 [[benchmarks]]
 quant = "nvfp4"
-checkpoint = "unsloth/Qwen3.8-27B-NVFP4"
+checkpoint = "nvidia/Qwen3.8-27B-NVFP4"
 gate = "decode-floor"
 recipe = "qwen3.8/qwen3.8-27b-nvfp4-unsloth"
 label = "Qwen3.8-27B dense (NVFP4, unsloth)"
@@ -231,10 +231,10 @@ noise = 0.5
 # The driver emits the MINIMUM completion_tokens across the 3 runs, so this
 # floor means "every run decoded at least 750 of the 1500 budget" — the same
 # vacuity pin the driver enforces (MIN_OUTPUT_TOKENS), restated where the
-# gate can see it. 750, not 1200: the calibrated instrument's natural stop
-# is a deterministic 915 tokens, and a pin above the instrument's own
-# reference behaviour would fail every honest run.
-min = 750.0
+# gate can see it. 700, not 1200: the served subject (nvidia/Qwen3.8-27B-NVFP4)
+# stops at a deterministic 717-718 tokens, and a pin above the instrument's
+# own reference behaviour would fail every honest run.
+min = 700.0
 
 [benchmarks.metrics.runs]
 # EXACT pin, like the BFCL draw size: a different run count is a different
@@ -266,7 +266,7 @@ max = 3.0
 
 [[benchmarks]]
 quant = "nvfp4"
-checkpoint = "unsloth/Qwen3.8-27B-NVFP4"
+checkpoint = "nvidia/Qwen3.8-27B-NVFP4"
 gate = "concurrency-sweep"
 recipe = "qwen3.8/qwen3.8-27b-nvfp4-unsloth"
 label = "Qwen3.8-27B dense (NVFP4, unsloth)"
@@ -491,7 +491,7 @@ max = 0.0
 
 [[benchmarks]]
 quant = "nvfp4"
-checkpoint = "unsloth/Qwen3.8-27B-NVFP4"
+checkpoint = "nvidia/Qwen3.8-27B-NVFP4"
 gate = "vision-fidelity"
 recipe = "qwen3.8/qwen3.8-27b-nvfp4-unsloth"
 label = "Qwen3.8-27B dense (NVFP4, unsloth)"
@@ -615,7 +615,7 @@ min = 1.0
 
 [[benchmarks]]
 quant = "nvfp4"
-checkpoint = "unsloth/Qwen3.8-27B-NVFP4"
+checkpoint = "nvidia/Qwen3.8-27B-NVFP4"
 gate = "video-fidelity"
 recipe = "qwen3.8/qwen3.8-27b-nvfp4-unsloth"
 label = "Qwen3.8-27B dense (NVFP4, unsloth)"

--- a/kernels/gb10/qwen3.8-27b/BENCH.toml
+++ b/kernels/gb10/qwen3.8-27b/BENCH.toml
@@ -25,7 +25,7 @@
 quant = "nvfp4"
 checkpoint = "nvidia/Qwen3.8-27B-NVFP4"
 gate = "agentic-webserver"
-recipe = "qwen3.8/qwen3.8-27b-nvfp4-unsloth"
+recipe = "qwen3.8/qwen3.8-27b-nvfp4-agentic"
 label = "Qwen3.8-27B dense (NVFP4, nvidia)"
 # NOT the default: the required Gate A subject stays the 35B MoE flagship
 # (qwen3.6-35b-a3b/BENCH.toml), whose recorded history is untouched. This
@@ -108,7 +108,7 @@ min = 10.0
 quant = "nvfp4"
 checkpoint = "nvidia/Qwen3.8-27B-NVFP4"
 gate = "bfcl-subset"
-recipe = "qwen3.8/qwen3.8-27b-nvfp4-unsloth-bfcl"
+recipe = "qwen3.8/qwen3.8-27b-nvfp4-bfcl"
 label = "Qwen3.8-27B dense (NVFP4, nvidia)"
 # THE REQUIRED bfcl-subset SUBJECT as of 2026-08-15 (flipped from Qwen3.6-27B per
 # maintainer: 3.6 is no longer worth requiring on every PR). The 3.6 entry in
@@ -145,7 +145,7 @@ max = 995.0
 
 [benchmarks.metrics.overall_accuracy]
 # Measured 84.22 (2026-08-14, dgx1, golden draw n=995 seed 42, temp 0,
-# recipe qwen3.8/qwen3.8-27b-nvfp4-unsloth-bfcl). Bar set at the measured
+# recipe qwen3.8/qwen3.8-27b-nvfp4-bfcl). Bar set at the measured
 # value less the documented +-0.4 MTP-nondeterminism noise floor.
 min = 83.82
 noise = 0.4
@@ -189,7 +189,7 @@ noise = 0.4
 quant = "nvfp4"
 checkpoint = "nvidia/Qwen3.8-27B-NVFP4"
 gate = "decode-floor"
-recipe = "qwen3.8/qwen3.8-27b-nvfp4-unsloth"
+recipe = "qwen3.8/qwen3.8-27b-nvfp4-agentic"
 label = "Qwen3.8-27B dense (NVFP4, nvidia)"
 default = true
 status = "measured"
@@ -266,7 +266,7 @@ max = 3.0
 quant = "nvfp4"
 checkpoint = "nvidia/Qwen3.8-27B-NVFP4"
 gate = "concurrency-sweep"
-recipe = "qwen3.8/qwen3.8-27b-nvfp4-unsloth"
+recipe = "qwen3.8/qwen3.8-27b-nvfp4-agentic"
 label = "Qwen3.8-27B dense (NVFP4, nvidia)"
 default = true
 status = "measured"
@@ -491,7 +491,7 @@ max = 0.0
 quant = "nvfp4"
 checkpoint = "nvidia/Qwen3.8-27B-NVFP4"
 gate = "vision-fidelity"
-recipe = "qwen3.8/qwen3.8-27b-nvfp4-unsloth"
+recipe = "qwen3.8/qwen3.8-27b-nvfp4-agentic"
 label = "Qwen3.8-27B dense (NVFP4, nvidia)"
 default = false
 status = "measured"
@@ -615,7 +615,7 @@ min = 1.0
 quant = "nvfp4"
 checkpoint = "nvidia/Qwen3.8-27B-NVFP4"
 gate = "video-fidelity"
-recipe = "qwen3.8/qwen3.8-27b-nvfp4-unsloth"
+recipe = "qwen3.8/qwen3.8-27b-nvfp4-agentic"
 label = "Qwen3.8-27B dense (NVFP4, nvidia)"
 # `default = false` since 2026-08-15: qwen3.6-27b owns this gate's required
 # subject. Not a demotion of the checkpoint and not a lowered bar -- the


### PR DESCRIPTION
## Summary

The qwen3.8-27b recipes now serve `nvidia/Qwen3.8-27B-NVFP4` (Atlas-Inf/sparkrun-recipes#7), so the six gate entries that drive them must declare that checkpoint — the gate refuses to score one checkpoint against another's thresholds:

```
Error: recipe "qwen3.8/qwen3.8-27b-nvfp4-unsloth" serves "nvidia/Qwen3.8-27B-NVFP4"
       but decode-floor's baseline is defined on "unsloth/Qwen3.8-27B-NVFP4".
```

## Why the checkpoint moves

The unsloth build keeps **both** an FP8 copy (prefill GEMM) and an NVFP4 copy (decode) for its 303 ignored modules: 29.98 GB of layer construction against 15.85 GB for the modelopt build. At the decode-floor instrument (`--max-batch-size 32`, K4, 32k, util 0.85) that is 59.5 GB pre-KV + 43.0 GB reserve against a 101.7 GB budget — **it cannot serve at all**, on `main` or on any branch. The nvidia checkpoint fits the same flags with 36.0 GB of KV cache.

## `MIN_OUTPUT_TOKENS` 750 → 700

The nvidia checkpoint's natural stop on the MinHeap fixture is a deterministic **717–718** tokens, against unsloth's 915. A vacuity pin above the subject's own reference behaviour fails every honest run by construction — the same rule that produced the 1200 → 750 move at the 2026-08-15 promotion. 700 keeps the pin's purpose (a 49-token burst can never read as a decode measurement) while sitting under the narrower stop.

## Validation

`decode-floor` through the gate's own driver, **PASS**, on reiner (GB10, driver 580.126.09):

```
median decode 26.2 tok/s (floor 20.5)   accept_len_mean 2.77   min output 717/1500
```

Four driver passes = 12 runs: per-run 26.1–27.1 tok/s, medians 26.1–26.3, sigma ~0.36. The rate floor is retained at 21.0 (mean minus ~5, far outside the noise band) rather than ratcheted — a tighter floor is derivable from this basis but not agreed. The decode-floor note records the new basis.

## Recipe consolidation

The qwen3.8-27b recipes are now `qwen3.8-27b-nvfp4` / `-agentic` / `-concurrency` / `-bfcl` (sparkrun-recipes#7): `-latency` was an exact duplicate of the flagship and is gone, and the ids no longer carry a checkpoint vendor. The five agentic-driven entries point at `-agentic`; bfcl keeps its own recipe — its 13 deltas from the flagship are expressible as overrides, but `gate::bench_tests` pins that entry's overrides as EMPTY precisely because its bars were measured by that exact config.

Validated after the repoint: `decode-floor` PASS, median 26.4 tok/s, accept_len_mean 2.77, min output 717/1500.

## Not in this PR

The other five gates now *serve* nvidia but their thresholds are still unsloth-calibrated (`ttft-warm/cold`, `concurrency-sweep`, `vision/video-fidelity`, `agentic-webserver`, and the `bfcl-subset` score baselines). Each needs re-basing on the nvidia instrument; `decode-floor` is the one proven here.

Generated with [Devin](https://devin.ai)
